### PR TITLE
Fixed Modal not closing when clicking outside of the dialog

### DIFF
--- a/src/BlazorStrap/Modal.cshtml
+++ b/src/BlazorStrap/Modal.cshtml
@@ -64,6 +64,7 @@
     {
         if (!_dontclickWasClicked) IsOpen = false;
         _dontclickWasClicked = false;
+        StateHasChanged();
     }
 
     void dontclick(UIMouseEventArgs e)


### PR DESCRIPTION
Fixes Modal not closing when clicking outside of the dialog.