### PR TITLE
Fix tooltips arrow color and remove unused class

### DIFF
--- a/src/BlazorStrap/wwwroot/blazorStrap.js
+++ b/src/BlazorStrap/wwwroot/blazorStrap.js
@@ -19,13 +19,13 @@
         function mouseoverHandler() {
             reference.removeEventListener("mouseover", mouseoverHandler);
             reference.addEventListener("mouseout", mouseoutHandler);
-            tooltip.className = "tooltip fade show bs-popover-" + placement;
+            tooltip.className = "tooltip fade show bs-tooltip-" + placement;
             instance = showPopper(reference, tooltip, arrow, placement);
         }
         function mouseoutHandler() {
             reference.removeEventListener("mouseout", mouseoutHandler);
             reference.addEventListener("mouseover", mouseoverHandler);
-            tooltip.className = "tooltip hide";
+            tooltip.className = "tooltip";
             if (instance) {
                 instance.destroy && instance.destroy();
                 instance = undefined;


### PR DESCRIPTION
The wrong component name was used to created computed class resulting in
wrong BS class beign applied to tooltip arrow and transparent
background.

The `hide` is not required, empty `tooltip` class hides the instance as
the opacity is being set to 0.

Thanks!