### PR TITLE
Samples: WASM Safari workaround

### DIFF
--- a/src/Sample/wwwroot/index.html
+++ b/src/Sample/wwwroot/index.html
@@ -42,6 +42,10 @@
 </head>
 <body>
     <app>Loading...</app>
+
+    <!-- temporary WORKAROUND for Safari https://github.com/mono/mono/issues/15588#issuecomment-529056521 -->
+    <script>var Module;</script>
+    
     <script src="_framework/blazor.webassembly.js"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 </body>


### PR DESCRIPTION
See https://github.com/mono/mono/issues/15588#issuecomment-529056521. blazorstrap.io currently won't load in preview versions of Safari (which will become non-preview in a few days); this one-liner tries to work around it.