### PR TITLE
Remove BS specific data attributes from Razor markup.

### DIFF
--- a/src/BlazorStrap/Components/BSAlert.razor
+++ b/src/BlazorStrap/Components/BSAlert.razor
@@ -7,7 +7,7 @@
         @ChildContent
         @if (IsDismissible)
         {
-            <button @onclick="OnClick" type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <button @onclick="OnClick" type="button" class="close" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
             </button>
         }

--- a/src/BlazorStrap/Components/BSToast.Razor
+++ b/src/BlazorStrap/Components/BSToast.Razor
@@ -26,7 +26,7 @@ Use With:
 			//ToDo: For best results, use "PrettyDate" C# Extension on `DateTime.ToString()`
 			<small class="text-muted">@TimeStamp.Value.ToString(DateFormat)</small>
 		}
-		<button @onclick="OnClick" type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
+		<button @onclick="OnClick" type="button" class="ml-2 mb-1 close" aria-label="Close">
 			<span aria-hidden="true">&times;</span>
 		</button>
 	</div>

--- a/src/BlazorStrap/Components/Layout/BSCollapseToggle.razor
+++ b/src/BlazorStrap/Components/Layout/BSCollapseToggle.razor
@@ -1,6 +1,6 @@
 ﻿@namespace BlazorStrap
 @inherits BSCollapseToggleBase
 
-        <DynamicElement @attributes="@UnknownParameters" TagName="@Tag" class="@Classname" href="@href" type="@Type" @onclick="OnClickEvent" data-toggle="collapse" aria-expanded="@CollapseItem?.Collapse?.IsOpen.ToString().ToLower()">
+        <DynamicElement @attributes="@UnknownParameters" TagName="@Tag" class="@Classname" href="@href" type="@Type" @onclick="OnClickEvent" aria-expanded="@CollapseItem?.Collapse?.IsOpen.ToString().ToLower()">
             @ChildContent
         </DynamicElement>

--- a/src/BlazorStrap/Components/Model/BSModalHeader.razor
+++ b/src/BlazorStrap/Components/Model/BSModalHeader.razor
@@ -3,7 +3,7 @@
 
 <DynamicElement @attributes="@UnknownParameters" TagName="div" class="@divClassname">
     <h5 class="@headingClassname">@ChildContent</h5>
-    <button type="button" class="close" data-dismiss="modal" aria-label="Close" @onclick="OnClick" autofocus>
+    <button type="button" class="close" aria-label="Close" @onclick="OnClick" autofocus>
         <span aria-hidden="true">&times;</span>
     </button>
 </DynamicElement>


### PR DESCRIPTION
The Bootstrap specific data atributes are not used in detail for Alert,
Toast, Toggle and Modal. They are relevant only when using automated
feaetures of BS components backed by plain JavaScript implementation.

Thanks!