### PR TITLE
Sync customizer config with BS CSS3 properties

### DIFF
--- a/src/BlazorStrap/Components/BSCustomizer.razor.cs
+++ b/src/BlazorStrap/Components/BSCustomizer.razor.cs
@@ -34,6 +34,8 @@ namespace BlazorStrap
         public string BreakpointMS { get; set; }
         public string BreakpointLG { get; set; }
         public string BreakpointXL { get; set; }
+        public string FontFamilySansSerif { get; set; }
+        public string FontFamilyMonospace { get; set; }
 
     }
 }


### PR DESCRIPTION
Add missing:
- font family sans-serif
- font family monospace

Ref:
https://github.com/twbs/bootstrap/blob/master/scss/_root.scss#L13-L14

Thanks!