### PR TITLE
Added MaxDate to BSinput and BSBasicInput

### DIFF
--- a/src/BlazorStrap/Components/Forms/BSBasicInput.cs
+++ b/src/BlazorStrap/Components/Forms/BSBasicInput.cs
@@ -41,6 +41,7 @@ namespace BlazorStrap
         [Parameter] public Expression<Func<object>> For { get; set; }
         [Parameter] public InputType InputType { get; set; } = InputType.Text;
         [Parameter] public Size Size { get; set; } = Size.None;
+        [Parameter] public string MaxDate { get; set; } = "9999-12-31";
         [Parameter] public virtual T Value { get; set; }
         [Parameter] public virtual T RadioValue { get; set; }
         [Parameter] public virtual EventCallback<T> ValueChanged { get; set; }
@@ -141,8 +142,13 @@ namespace BlazorStrap
             {
                 builder.AddAttribute(8, "value", BindConverter.FormatValue(CurrentValueAsString));
                 builder.AddAttribute(10, "onchange", EventCallback.Factory.CreateBinder<string>(this, OnChange, CurrentValueAsString));
+
+                if (InputType == InputType.Date && !String.IsNullOrEmpty(MaxDate))
+                {
+                    builder.AddAttribute(11, "max", MaxDate);
+                }
             }
-            builder.AddContent(10, ChildContent);
+            builder.AddContent(12, ChildContent);
             builder.CloseElement();
         }
 

--- a/src/BlazorStrap/Components/Forms/BSBasicInput.cs
+++ b/src/BlazorStrap/Components/Forms/BSBasicInput.cs
@@ -119,8 +119,8 @@ namespace BlazorStrap
                 {
                     Value = ((string)(object)Value).ToLowerInvariant() != "false" ? (T)(object)"true" : (T)(object)"false";
                 }
-                builder.AddAttribute(8, "checked", Convert.ToBoolean(Value, CultureInfo.InvariantCulture));
-                builder.AddAttribute(9, "onclick", EventCallback.Factory.Create(this, OnClick));
+                builder.AddAttribute(9, "checked", Convert.ToBoolean(Value, CultureInfo.InvariantCulture));
+                builder.AddAttribute(10, "onclick", EventCallback.Factory.Create(this, OnClick));
             }
             else if(InputType == InputType.Radio)
             {
@@ -128,27 +128,27 @@ namespace BlazorStrap
                 {
                     if (RadioValue.Equals(Value))
                     {
-                        builder.AddAttribute(8, "checked", true);
-                        builder.AddAttribute(9, "onclick", EventCallback.Factory.Create(this, OnClick));
+                        builder.AddAttribute(9, "checked", true);
+                        builder.AddAttribute(10, "onclick", EventCallback.Factory.Create(this, OnClick));
                     }
                     else
                     {
-                        builder.AddAttribute(8, "checked", false);
-                        builder.AddAttribute(9, "onclick", EventCallback.Factory.Create(this, OnClick));
+                        builder.AddAttribute(9, "checked", false);
+                        builder.AddAttribute(10, "onclick", EventCallback.Factory.Create(this, OnClick));
                     }
                 }
             }
             else
             {
-                builder.AddAttribute(8, "value", BindConverter.FormatValue(CurrentValueAsString));
-                builder.AddAttribute(10, "onchange", EventCallback.Factory.CreateBinder<string>(this, OnChange, CurrentValueAsString));
+                builder.AddAttribute(9, "value", BindConverter.FormatValue(CurrentValueAsString));
+                builder.AddAttribute(11, "onchange", EventCallback.Factory.CreateBinder<string>(this, OnChange, CurrentValueAsString));
 
                 if (InputType == InputType.Date && !String.IsNullOrEmpty(MaxDate))
                 {
-                    builder.AddAttribute(11, "max", MaxDate);
+                    builder.AddAttribute(12, "max", MaxDate);
                 }
             }
-            builder.AddContent(12, ChildContent);
+            builder.AddContent(13, ChildContent);
             builder.CloseElement();
         }
 

--- a/src/BlazorStrap/Components/Forms/BSInput.cs
+++ b/src/BlazorStrap/Components/Forms/BSInput.cs
@@ -144,13 +144,13 @@ namespace BlazorStrap
             {
                 if (RadioValue.Equals(Value))
                 {
-                    builder.AddAttribute(8, "checked", true);
-                    builder.AddAttribute(9, "onclick", EventCallback.Factory.Create(this, OnClick));
+                    builder.AddAttribute(9, "checked", true);
+                    builder.AddAttribute(10, "onclick", EventCallback.Factory.Create(this, OnClick));
                 }
                 else
                 {
-                    builder.AddAttribute(8, "checked", false);
-                    builder.AddAttribute(9, "onclick", EventCallback.Factory.Create(this, OnClick));
+                    builder.AddAttribute(9, "checked", false);
+                    builder.AddAttribute(10, "onclick", EventCallback.Factory.Create(this, OnClick));
                 }
             }
             else

--- a/src/BlazorStrap/Components/Forms/BSInput.cs
+++ b/src/BlazorStrap/Components/Forms/BSInput.cs
@@ -52,6 +52,7 @@ namespace BlazorStrap
 
         [Parameter] public InputType InputType { get; set; } = InputType.Text;
         [Parameter] public Size Size { get; set; } = Size.None;
+        [Parameter] public string MaxDate { get; set; } = "9999-12-31";
         [Parameter] public virtual T RadioValue { get; set; }
         [Parameter] public bool IsReadonly { get; set; }
         [Parameter] public bool IsPlaintext { get; set; }
@@ -156,10 +157,15 @@ namespace BlazorStrap
             {
                 builder.AddAttribute(9, "value", BindConverter.FormatValue(CurrentValueAsString));
                 builder.AddAttribute(10, "onchange", EventCallback.Factory.CreateBinder<string>(this, OnChange, CurrentValueAsString));
+
+                if (InputType == InputType.Date && !String.IsNullOrEmpty(MaxDate))
+                {
+                   builder.AddAttribute(11, "max", MaxDate);
+                }
             }
 
-            builder.AddAttribute(11, "onblur", EventCallback.Factory.Create(this, () => { _touched = true; ValidateField(base.FieldIdentifier) ; }));
-            builder.AddContent(12, ChildContent);
+            builder.AddAttribute(12, "onblur", EventCallback.Factory.Create(this, () => { _touched = true; ValidateField(base.FieldIdentifier) ; }));
+            builder.AddContent(13, ChildContent);
             builder.CloseElement();
         }
 


### PR DESCRIPTION
Addressing #227 .

Added generation of "max" attribute with a default of "9999-12-31" for date fields.
This will create the default behaviour of the year only allowing 4 digits for the year.

I also updated the attribute sequence numbers around the rendering of MaxDate to ensure no duplicates.

I wasn't able to figure out a way to test this unfortunately :(
It builds fine but couldn't get `Sample`, `SampleCore`, or `ServerSideSample` to run for me.
I also couldn't find any guidelines on testing so let me know if there is a process for it that I missed.