### PR TITLE
Update BSTable.razor.cs to fix typo for IsHovarable => IsHoverable

### DIFF
--- a/src/BlazorStrap/Components/Layout/BSTable.razor.cs
+++ b/src/BlazorStrap/Components/Layout/BSTable.razor.cs
@@ -22,7 +22,7 @@ namespace BlazorStrap
         [Parameter] public bool IsStriped { get; set; }
         [Parameter] public bool IsBordered { get; set; }
         [Parameter] public bool IsBorderless { get; set; }
-        [Parameter] public bool IsHovarable { get; set; }
+        [Parameter] public bool IsHoverable { get; set; }
         [Parameter] public bool IsSmall { get; set; }
         [Parameter] public bool IsResponsive { get; set; }
         [Parameter] public string Class { get; set; }


### PR DESCRIPTION
The name of the property is incorrect and does not match the documentation title or the bootstrap class name.