### PR TITLE
Added 4 new options on bootstrap modal component. IsFullWidth, IsBottom, IsFullHeight and IsFullScreen.

### DIFF
--- a/src/BlazorStrap/Components/Model/BSModal.razor
+++ b/src/BlazorStrap/Components/Model/BSModal.razor
@@ -3,7 +3,7 @@
 
 
 <DynamicElement @attributes="@UnknownParameters" style="@Styles"  TagName="div" class="@Classname" tabindex="-1" role="dialog" @onfocus="OnBackdropClick" @bind-ElementRef="MyRef" >
-    <div class="@InnerClassname" role="document"  tabindex="-2">
+    <div class="@InnerClassname" role="document" style="@InnerStyles"  tabindex="-2">
         <div class="modal-content"  @ref="Me">
             @ChildContent
         </div>

--- a/src/BlazorStrap/Components/Model/BSModal.razor.cs
+++ b/src/BlazorStrap/Components/Model/BSModal.razor.cs
@@ -17,6 +17,10 @@ namespace BlazorStrap
         [Parameter] public bool IgnoreClickOnBackdrop { get; set; }
         [Parameter] public bool IgnoreEscape { get; set; }
         [Parameter] public bool IsCentered { get; set; }
+        [Parameter] public bool IsBottom { get; set; }
+        [Parameter] public bool IsFullWidth { get; set; }
+        [Parameter] public bool IsFullHeight { get; set; }
+        [Parameter] public bool IsFullScreen { get; set; }
         [Parameter] public bool NoBackdrop { get; set; }
         [Parameter] public EventCallback<BSModalEvent> ShowEvent { get; set; }
         [Parameter] public EventCallback<BSModalEvent> ShownEvent { get; set; }
@@ -45,10 +49,22 @@ namespace BlazorStrap
         {
             get
             {
-             //   var display = DisableAnimations || (IsOpen ?? true)
-                 //   ? (IsOpen ?? false) ? "display: block; padding-right: 17px;" : null
-                var display= (_toggleModel) ? "display: block; padding-right: 17px;" : null;
+                //   var display = DisableAnimations || (IsOpen ?? true)
+                //   ? (IsOpen ?? false) ? "display: block; padding-right: 17px;" : null
+                // we don't need any -> padding-right: 17px;
+                var display = (_toggleModel) ? "display: block;" : null;
                 return $"{Style} {display}".Trim();
+            }
+        }
+        protected string InnerStyles
+        {
+            get
+            {
+                var fullWidthStyle = (IsFullWidth) ? "width:100%;min-width:100%;margin-left:0;margin-right:0;" : null;
+                var bottomStyle = (IsBottom) ? "display: flex;-ms-flex-align: flex-end;align-items: flex-end;height:100%;min-height:100%;margin-top:0;margin-bottom:0;" : null;
+                var fullHeightStyle = (IsFullHeight) ? "display: flex;-ms-flex-align: stretch;align-items: stretch;height:100%;min-height:100%;margin-top:0;margin-bottom:0;" : null;
+                var fullScreenStyle = (IsFullScreen) ? "display: flex;-ms-flex-align: stretch;align-items: stretch;width:100%;min-width:100%;height:100%;min-height:100%;margin:0;" : null;
+                return $" {fullWidthStyle} {bottomStyle} {fullScreenStyle} {fullHeightStyle}";
             }
         }
 

--- a/src/SampleCore/Pages/Modals.razor
+++ b/src/SampleCore/Pages/Modals.razor
@@ -3,7 +3,7 @@
 <h1>Modals</h1>
 
 <div class="docs-example modal-example">
-    <BSModal IsOpen="true" NoBackdrop="true" Class="show"> 
+    <BSModal IsOpen="true" NoBackdrop="true" Class="show">
         <BSModalHeader>Modal title</BSModalHeader>
         <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
         <BSModalFooter>
@@ -66,6 +66,82 @@
 </div>
 <PrettyCode CodeFile="_content/SampleCore/snippets/modals/modals4.html" />
 
+<h3>Full Width Modal</h3>
+
+<div class="docs-example">
+    <BSButton Color="Color.Primary" @onclick="onclick5">Full width modal</BSButton>
+    <BSModal IsFullWidth="true" @bind-IsOpen="@IsOpen5">
+        <BSModalHeader OnClick="onclick5">Modal title</BSModalHeader>
+        <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+        <BSModalFooter>
+            <BSButton Color="Color.Primary" @onclick="onclick5">Do Something</BSButton>
+            <BSButton Color="Color.Secondary" @onclick="onclick5">Cancel</BSButton>
+        </BSModalFooter>
+    </BSModal>
+</div>
+<PrettyCode CodeFile="_content/SampleCore/snippets/modals/modals5.html" />
+
+<h3>Bottom Modal</h3>
+
+<div class="docs-example">
+    <BSButton Color="Color.Primary" @onclick="onclick6">Bottom modal</BSButton>
+    <BSModal IsBottom="true" @bind-IsOpen="@IsOpen6">
+        <BSModalHeader OnClick="onclick6">Modal title</BSModalHeader>
+        <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+        <BSModalFooter>
+            <BSButton Color="Color.Primary" @onclick="onclick6">Do Something</BSButton>
+            <BSButton Color="Color.Secondary" @onclick="onclick6">Cancel</BSButton>
+        </BSModalFooter>
+    </BSModal>
+</div>
+<PrettyCode CodeFile="_content/SampleCore/snippets/modals/modals6.html" />
+
+<h3>Bottom Sheet like modal</h3>
+
+<div class="docs-example">
+    <BSButton Color="Color.Primary" @onclick="onclick7">Bottom sheet modal</BSButton>
+    <BSModal IsBottom="true" IsFullWidth="true" @bind-IsOpen="@IsOpen7">
+        <BSModalHeader OnClick="onclick7">Modal title</BSModalHeader>
+        <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+        <BSModalFooter>
+            <BSButton Color="Color.Primary" @onclick="onclick7">Do Something</BSButton>
+            <BSButton Color="Color.Secondary" @onclick="onclick7">Cancel</BSButton>
+        </BSModalFooter>
+    </BSModal>
+</div>
+<PrettyCode CodeFile="_content/SampleCore/snippets/modals/modals7.html" />
+
+
+<h3>Full Height Modal</h3>
+
+<div class="docs-example">
+    <BSButton Color="Color.Primary" @onclick="onclick8">Full height modal</BSButton>
+    <BSModal IsFullHeight="true" @bind-IsOpen="@IsOpen8">
+        <BSModalHeader OnClick="onclick8">Modal title</BSModalHeader>
+        <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+        <BSModalFooter>
+            <BSButton Color="Color.Primary" @onclick="onclick8">Do Something</BSButton>
+            <BSButton Color="Color.Secondary" @onclick="onclick8">Cancel</BSButton>
+        </BSModalFooter>
+    </BSModal>
+</div>
+<PrettyCode CodeFile="_content/SampleCore/snippets/modals/modals8.html" />
+
+<h3>Fullscreen modal</h3>
+
+<div class="docs-example">
+    <BSButton Color="Color.Primary" @onclick="onclick9">Fullscreen modal</BSButton>
+    <BSModal IsFullScreen="true" @bind-IsOpen="@IsOpen9">
+        <BSModalHeader OnClick="onclick9">Modal title</BSModalHeader>
+        <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+        <BSModalFooter>
+            <BSButton Color="Color.Primary" @onclick="onclick9">Do Something</BSButton>
+            <BSButton Color="Color.Secondary" @onclick="onclick9">Cancel</BSButton>
+        </BSModalFooter>
+    </BSModal>
+</div>
+<PrettyCode CodeFile="_content/SampleCore/snippets/modals/modals9.html" />
+
 <h3>Ignore Click on Back Drop</h3>
 
 <p>You can set <code>IgnoreClickOnBackDrop</code> to prevent the user closing the model by clicking on the back drop.</p>
@@ -94,6 +170,36 @@
     void onclick4(MouseEventArgs e)
     {
         IsOpen4 = !IsOpen4;
+        StateHasChanged();
+    }
+    bool IsOpen5 { get; set; }
+    void onclick5(MouseEventArgs e)
+    {
+        IsOpen5 = !IsOpen5;
+        StateHasChanged();
+    }
+    bool IsOpen6 { get; set; }
+    void onclick6(MouseEventArgs e)
+    {
+        IsOpen6 = !IsOpen6;
+        StateHasChanged();
+    }
+    bool IsOpen7 { get; set; }
+    void onclick7(MouseEventArgs e)
+    {
+        IsOpen7 = !IsOpen7;
+        StateHasChanged();
+    }
+    bool IsOpen8 { get; set; }
+    void onclick8(MouseEventArgs e)
+    {
+        IsOpen8 = !IsOpen8;
+        StateHasChanged();
+    }
+    bool IsOpen9 { get; set; }
+    void onclick9(MouseEventArgs e)
+    {
+        IsOpen9 = !IsOpen9;
         StateHasChanged();
     }
 }

--- a/src/SampleCore/SampleCore.csproj
+++ b/src/SampleCore/SampleCore.csproj
@@ -25,4 +25,12 @@
     <Content Remove="wwwroot\snippets\alerts\alerts5.html" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Remove="wwwroot\snippets\modals\modals5.html" />
+    <EmbeddedResource Remove="wwwroot\snippets\modals\modals6.html" />
+    <EmbeddedResource Remove="wwwroot\snippets\modals\modals7.html" />
+    <EmbeddedResource Remove="wwwroot\snippets\modals\modals8.html" />
+    <EmbeddedResource Remove="wwwroot\snippets\modals\modals9.html" />
+  </ItemGroup>
+
 </Project>

--- a/src/SampleCore/wwwroot/snippets/modals/modals5.html
+++ b/src/SampleCore/wwwroot/snippets/modals/modals5.html
@@ -1,0 +1,9 @@
+﻿<BSButton Color="Color.Primary" @onclick="onclick5">Large modal</BSButton>
+<BSModal IsFullWidth="true" @bind-IsOpen="@IsOpen5">
+    <BSModalHeader OnClick="onclick5">Modal title</BSModalHeader>
+    <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+    <BSModalFooter>
+        <BSButton Color="Color.Primary" @onclick="onclick5">Do Something</BSButton>
+        <BSButton Color="Color.Secondary" @onclick="onclick5">Cancel</BSButton>
+    </BSModalFooter>
+</BSModal>

--- a/src/SampleCore/wwwroot/snippets/modals/modals6.html
+++ b/src/SampleCore/wwwroot/snippets/modals/modals6.html
@@ -1,0 +1,9 @@
+﻿<BSButton Color="Color.Primary" @onclick="onclick6">Large modal</BSButton>
+<BSModal IsBottom="true" @bind-IsOpen="@IsOpen6">
+    <BSModalHeader OnClick="onclick6">Modal title</BSModalHeader>
+    <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+    <BSModalFooter>
+        <BSButton Color="Color.Primary" @onclick="onclick6">Do Something</BSButton>
+        <BSButton Color="Color.Secondary" @onclick="onclick6">Cancel</BSButton>
+    </BSModalFooter>
+</BSModal>

--- a/src/SampleCore/wwwroot/snippets/modals/modals7.html
+++ b/src/SampleCore/wwwroot/snippets/modals/modals7.html
@@ -1,0 +1,9 @@
+﻿<BSButton Color="Color.Primary" @onclick="onclick7">Large modal</BSButton>
+<BSModal IsBottom="true" IsFullWidth="true" @bind-IsOpen="@IsOpen7">
+    <BSModalHeader OnClick="onclick7">Modal title</BSModalHeader>
+    <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+    <BSModalFooter>
+        <BSButton Color="Color.Primary" @onclick="onclick7">Do Something</BSButton>
+        <BSButton Color="Color.Secondary" @onclick="onclick7">Cancel</BSButton>
+    </BSModalFooter>
+</BSModal>

--- a/src/SampleCore/wwwroot/snippets/modals/modals8.html
+++ b/src/SampleCore/wwwroot/snippets/modals/modals8.html
@@ -1,0 +1,9 @@
+﻿<BSButton Color="Color.Primary" @onclick="onclick8">Full height modal</BSButton>
+<BSModal IsFullHeight="true" @bind-IsOpen="@IsOpen8">
+    <BSModalHeader OnClick="onclick8">Modal title</BSModalHeader>
+    <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+    <BSModalFooter>
+        <BSButton Color="Color.Primary" @onclick="onclick8">Do Something</BSButton>
+        <BSButton Color="Color.Secondary" @onclick="onclick8">Cancel</BSButton>
+    </BSModalFooter>
+</BSModal>

--- a/src/SampleCore/wwwroot/snippets/modals/modals9.html
+++ b/src/SampleCore/wwwroot/snippets/modals/modals9.html
@@ -1,0 +1,9 @@
+﻿<BSButton Color="Color.Primary" @onclick="onclick9">Fullscreen modal</BSButton>
+<BSModal IsFullScreen="true" @bind-IsOpen="@IsOpen9">
+    <BSModalHeader OnClick="onclick9">Modal title</BSModalHeader>
+    <BSModalBody><p>Modal body text goes here.</p></BSModalBody>
+    <BSModalFooter>
+        <BSButton Color="Color.Primary" @onclick="onclick9">Do Something</BSButton>
+        <BSButton Color="Color.Secondary" @onclick="onclick9">Cancel</BSButton>
+    </BSModalFooter>
+</BSModal>


### PR DESCRIPTION
Added 4 new options on bootstrap modal components. IsFullWidth for a full width modal, IsBottom to place modal at the bottom of the screen, IsFullHeight to place modal on the full height of the screen, IsFullScreen for a full screen window. You can have a bottom sheet like modal using the combined options of IsFullWidth and IsBottom. Modal examples pages have been updated with this changes as well.

### Full Width Modal
![image](https://user-images.githubusercontent.com/5600102/78177164-ae01f100-742b-11ea-91aa-fcb406b3af84.png)

### Bottom Modal
![image](https://user-images.githubusercontent.com/5600102/78177238-ceca4680-742b-11ea-8278-0bf9eee02b6d.png)

### Bottom Sheet like Modal
![image](https://user-images.githubusercontent.com/5600102/78177317-f1f4f600-742b-11ea-83f6-535d80031295.png)

### Full Height Modal
![image](https://user-images.githubusercontent.com/5600102/78177401-15b83c00-742c-11ea-91a6-0d344e5ad05f.png)

### Full Screen Modal
![image](https://user-images.githubusercontent.com/5600102/78177479-32ed0a80-742c-11ea-887e-219434ab6f8a.png)

