### PR TITLE
Fixed typo on example page: IsHovarable -> IsHoverable

### DIFF
--- a/src/SampleCore/Pages/Tables.razor
+++ b/src/SampleCore/Pages/Tables.razor
@@ -348,7 +348,7 @@
 <h3>Hoverable rows</h3>
 
 <div class="docs-example">
-    <BSTable IsHovarable="true">
+    <BSTable IsHoverable="true">
         <thead>
             <tr>
                 <th scope="col">#</th>

--- a/src/SampleCore/wwwroot/snippets/tables/tables10.html
+++ b/src/SampleCore/wwwroot/snippets/tables/tables10.html
@@ -1,4 +1,4 @@
-﻿<BSTable IsHovarable="true">
+﻿<BSTable IsHoverable="true">
     <thead>
         <tr>
             <th scope="col">#</th>


### PR DESCRIPTION
Fixed Typo on examples: IsHovarable -> IsHoverable