### PR TITLE
Added missing class on ListGroupItem -> list-group-item-action when ListGroupType != ListGroupType.List

### DIFF
--- a/src/BlazorStrap/Components/ListGroup/BSListGroupItem.razor.cs
+++ b/src/BlazorStrap/Components/ListGroup/BSListGroupItem.razor.cs
@@ -14,7 +14,9 @@ namespace BlazorStrap
             .AddClass($"list-group-item-{Color.ToDescriptionString()}", Color != Color.None)
             .AddClass("active", IsActive)
             .AddClass("disabled", IsDisabled && ListGroupType != ListGroupType.Button)
-            .AddClass("list-group-item-action", ListGroupType != ListGroupType.List)
+            .AddClass("list-group-item-action", ListGroupType != ListGroupType.List && 
+                                                (ListGroupType == ListGroupType.Button || 
+                                                ListGroupType == ListGroupType.Link))
             .AddClass(Class)
         .Build();
 

--- a/src/BlazorStrap/Components/ListGroup/BSListGroupItem.razor.cs
+++ b/src/BlazorStrap/Components/ListGroup/BSListGroupItem.razor.cs
@@ -14,6 +14,7 @@ namespace BlazorStrap
             .AddClass($"list-group-item-{Color.ToDescriptionString()}", Color != Color.None)
             .AddClass("active", IsActive)
             .AddClass("disabled", IsDisabled && ListGroupType != ListGroupType.Button)
+            .AddClass("list-group-item-action", ListGroupType != ListGroupType.List)
             .AddClass(Class)
         .Build();
 


### PR DESCRIPTION
Bootstrap href or button on list groups uses the class list-group-item-action which provides actionable feedback to the user.