### PR TITLE
Fix BSCollapse not actually showing/hiding

### DIFF
--- a/src/BlazorStrap/Components/Layout/BSCollapse.razor.cs
+++ b/src/BlazorStrap/Components/Layout/BSCollapse.razor.cs
@@ -75,6 +75,7 @@ namespace BlazorStrap
                 await HideEvent.InvokeAsync(BSCollapseEvent).ConfigureAwait(false);
                 EventQue.Add(HiddenEvent);
             }
+            StateHasChanged();
         }
         public async Task AnimationEnd()
         {


### PR DESCRIPTION
Fix BSCollapse not actually showing/hiding unless you are subscribed to the ShowEvent (to show) and the HideEvent (to hide)

This code wasn't working:

    <BSCollapseItem>
        <BSCollapseToggle IsLink="true">Toggle</BSCollapseToggle>
        <BSCollapse>
            <p>Content</p>
        </BSCollapse>
    </BSCollapseItem>

This code would work:

    <BSCollapseItem>
        <BSCollapseToggle IsLink="true">Toggle</BSCollapseToggle>
        <BSCollapse ShowEvent="@(() => Console.WriteLine("Show"))" HideEvent="@(() => Console.WriteLine("Hide"))">
            <p>Content</p>
        </BSCollapse>
    </BSCollapseItem>