### PR TITLE
Remote data table

### DIFF
--- a/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemoteDataTable.razor
+++ b/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemoteDataTable.razor
@@ -1,0 +1,46 @@
+﻿@namespace BlazorStrap.Extensions.DataComponents
+@typeparam TItem
+@inherits DataComponentBase<TItem>
+
+<RemotePagination HasNoData="HasNoData" IsLoading="IsLoading" Page="Page" RecordsPerPage="RecordsPerPage" TotalRecords="TotalRecords" UrlPattern="@UrlPattern" />
+
+<BSTable IsDark="@IsDark" IsBordered="@IsBordered" IsHoverable="@IsHoverable" IsResponsive="@IsResponsive"
+         IsStriped="@IsStriped" IsSmall="@IsSmall" IsBorderless="@IsBorderless">
+    <thead>
+        <CascadingValue Value="this">
+            @HeaderTemplate
+        </CascadingValue>
+    </thead>
+    <tbody>
+
+        @if (IsLoading)
+        {
+            <tr>
+                @LoadingTemplate
+            </tr>
+        }
+        else
+        {
+            if (HasNoData)
+            {
+                <tr>
+                    @NoDataTemplate
+                </tr>
+            }
+            else
+            {
+                @foreach (var item in Items)
+                {
+                    <tr>
+                        @ItemTemplate(item)
+                    </tr>
+                }
+            }
+        }
+    </tbody>
+    <tfoot>
+        @FooterTemplate
+    </tfoot>
+</BSTable>
+
+<RemotePagination HasNoData="HasNoData" IsLoading="IsLoading" Page="Page" RecordsPerPage="RecordsPerPage" TotalRecords="TotalRecords" UrlPattern="@UrlPattern" />

--- a/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemoteDataTable.razor.cs
+++ b/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemoteDataTable.razor.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace BlazorStrap.Extensions.DataComponents
+{
+    public partial class RemoteDataTable<TItem> : DataComponentBase<TItem>
+    {
+        // Original BSTable attributes to pass on.
+        [Parameter] public bool IsDark { get; set; }
+        [Parameter] public bool IsStriped { get; set; }
+        [Parameter] public bool IsBordered { get; set; }
+        [Parameter] public bool IsBorderless { get; set; }
+        [Parameter] public bool IsHoverable { get; set; }
+        [Parameter] public bool IsSmall { get; set; }
+        [Parameter] public bool IsResponsive { get; set; }
+        [Parameter] public string Class { get; set; }
+
+        //Remote Properties
+        [Parameter] public int Page { get; set; } = 1;
+        [Parameter] public int TotalRecords { get; set; }
+        [Parameter] public int RecordsPerPage { get; set; } = 50;
+        [Parameter] public string UrlPattern { get; set; }
+
+        // Render Fragments
+
+        /// <summary>
+        /// For adding header definitions to the Table.
+        /// It will be displayed in the head of the table.
+        /// </summary>
+        [Parameter] public RenderFragment HeaderTemplate { get; set; }
+
+        /// <summary>
+        /// For adding a footer to the table.
+        /// It will be displayed in the foot section of the table.
+        /// </summary>
+        [Parameter] public RenderFragment FooterTemplate { get; set; }
+
+    }
+}

--- a/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemotePagination.razor
+++ b/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemotePagination.razor
@@ -1,0 +1,44 @@
+﻿@namespace BlazorStrap.Extensions.DataComponents
+
+@if (TotalRecords != 0)
+{
+    @if (!IsLoading && !HasNoData)
+    {
+        <BSPagination Alignment="Alignment.Right">
+            <BSPaginationItem IsDisabled="@IsPreviousDisabled">
+                <BSPaginationLink Href="@(GetUrl(Page - 1))" PaginationLinkType="PaginationLinkType.PreviousIcon" />
+            </BSPaginationItem>
+            @for (int i = 0; i < Pages; i++)
+            {
+                int count = i + 1;
+                if (count == Page)
+                {
+                    <BSPaginationItem IsActive="true">
+                        <BSPaginationLink>@count <span class="sr-only">(current)</span></BSPaginationLink>
+                    </BSPaginationItem>
+                }
+                else
+                {
+                    <BSPaginationItem>
+                        <BSPaginationLink Href="@(GetUrl(count))">@count</BSPaginationLink>
+                    </BSPaginationItem>
+                }
+
+            }
+            <BSPaginationItem IsDisabled="@IsNextDisabled">
+                <BSPaginationLink Href="@(GetUrl(Page + 1))" PaginationLinkType="PaginationLinkType.NextIcon" />
+            </BSPaginationItem>
+        </BSPagination>
+    }
+    else
+    {
+        <BSPagination Alignment="Alignment.Right" Style="visibility: hidden;">
+            <BSPaginationItem IsDisabled="true">
+                <BSPaginationLink Href="#" PaginationLinkType="PaginationLinkType.PreviousIcon" />
+            </BSPaginationItem>
+            <BSPaginationItem IsDisabled="true">
+                <BSPaginationLink Href="#" PaginationLinkType="PaginationLinkType.NextIcon" />
+            </BSPaginationItem>
+        </BSPagination>
+    }
+}

--- a/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemotePagination.razor.cs
+++ b/src/BlazorStrap.Extensions.DataComponents/Components/BSDataTable/RemotePagination.razor.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.AspNetCore.Components;
+using System;
+
+namespace BlazorStrap.Extensions.DataComponents
+{
+    public partial class RemotePagination : ComponentBase
+    {
+        [Parameter] public int Page { get; set; } = 1;
+        [Parameter] public int TotalRecords { get; set; }
+        [Parameter] public int RecordsPerPage { get; set; } = 50;
+        [Parameter] public bool IsLoading { get; set; }
+        [Parameter] public bool HasNoData { get; set; }
+        [Parameter] public string UrlPattern { get; set; }
+
+        private int Pages => (int)Math.Ceiling((float)TotalRecords / RecordsPerPage);
+        private bool IsPreviousDisabled => Page == 1;
+        private bool IsNextDisabled => Page == Pages;
+
+        /// <summary>
+        /// Replace variables in UrlPattern to create a url to a page.
+        /// In the future other variables can be added such as sort and filter
+        /// 
+        /// Variables are:
+        /// 
+        /// {page} - will get replaced with page number
+        /// </summary>
+        /// <param name="page"></param>
+        /// <returns></returns>
+        private string GetUrl(int page)
+        {
+            return UrlPattern.Replace("{page}", page.ToString());
+        }
+    }
+}


### PR DESCRIPTION
**WIP**

Adds the start of a remote data table. Builds off of DataTable (Note: right now it doesn't use the DataTable internally because they might not work the same way once you add sorting and filtering, but if possible similar functionality should be merged).

Right now, only supports pagination, not sorting filtering or any other advanced functionality. It does it by having the user supply the items just like in the regular DataTable, plus page number, total records and per page counts. As well as a UrlPattern (Have to use urls/routing because OnClick of BSPaginationLink is broken #320). Although personally, I prefer url routing when possible as it makes the app more browser friendly, but not everyone will want that.

I did not add documentation yet, but I wanted to get thoughts on this. Tagging @MasterSkriptor as well since he wrote our original DataTable. 

