### PR TITLE
Fixes #270 tab exception. Also fixes next tab loading when leaving page.

### DIFF
--- a/src/BlazorStrap/Components/Tabs/BSTab.razor.cs
+++ b/src/BlazorStrap/Components/Tabs/BSTab.razor.cs
@@ -76,8 +76,8 @@ namespace BlazorStrap
                 if (Group.Disposing) return;
                 //Locks updates when deleting tabs
                 Group.Tabs.Remove(this);
-                Group.Selected = (Group.Selected == this) ? Group.Tabs.FirstOrDefault() : Group.Selected;
                 Group.Disposing = true;
+                Group.Selected = (Group.Selected == this) ? Group.Tabs.FirstOrDefault() : Group.Selected;
             }
         }
     }


### PR DESCRIPTION
This fixes the exception I reported in 270.

Also found another issue that this fixes. I have a page with 2 tabs where first tab is selected. When I go to another page, it first changes tab and runs Invoke on show method for second tab before navigating to other page.