### PR TITLE
Alternative FluentValidatorInjected component to use DI to inject a validator

### DIFF
--- a/src/BlazorStrap.Extensions.FluentValidation/FluentValidation.cs
+++ b/src/BlazorStrap.Extensions.FluentValidation/FluentValidation.cs
@@ -17,7 +17,7 @@ namespace BlazorStrap.Extensions.FluentValidation
         }
     }
 
-    public class InjectFluentValidator : BaseFluentValidator
+    public class FluentValidatorInjected : BaseFluentValidator
     {
         [Inject] private IServiceProvider _services { get; set; }
 


### PR DESCRIPTION
I have a FluentValidator that requires resolving dependencies via DI.

I am unable to use the current component for FluentValidator as it requires me to pass in the type with a new() constraint, which then just creates the validator, without resolving it.

As changing this would be a breaking change I have added an alternative InjectFluentValidator component which detects the IValidator<> type required based on the EditContext model and injects it.

This requires the validator to be registered in the service collection, eg:

    services.AddTransient<IValidator<MyModel>, MyModelValidator>();

Open to discussion if there is a better way of solving this problem?