### PR TITLE
Fixed bug #330

### DIFF
--- a/src/BlazorStrap/wwwroot/css/cromefix.css
+++ b/src/BlazorStrap/wwwroot/css/cromefix.css
@@ -2,3 +2,12 @@
 div.modal-header > button.close:focus {
     outline: 0px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+    .collapsing {
+        transition: step-end !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+}
+}

--- a/src/SampleCore/Pages/Samples/Issue330.razor
+++ b/src/SampleCore/Pages/Samples/Issue330.razor
@@ -1,0 +1,24 @@
+﻿@page "/samples/Issue330"
+
+<h3>issue330</h3>
+
+<div>
+    <a class="justify-content-between align-items-center d-flex" @onclick="Toggle">
+        <h3 class="d-flex align-items-center">
+            Click here
+        </h3>
+    </a>
+    <BSCollapse IsOpen="IsOpen">
+        Test content
+    </BSCollapse>
+</div>
+
+@code {
+    private bool IsOpen { get; set; } = false;
+
+    private void Toggle(MouseEventArgs e)
+    {
+        IsOpen = !IsOpen;
+        StateHasChanged();
+    }
+}


### PR DESCRIPTION
This fix overrides Bootstraps CSS to stop animations when reduced animations is turned on. Instead it sets the animations to last .001ms. This accomplishes the need for reduced animations for those with physical issues such as vestibular disorders while still allowing our events to fire normally.

This PR fixes #330 