### PR TITLE
Fixed BSInput Type=Time not working

### DIFF
--- a/src/BlazorStrap/Components/Forms/BSInput.cs
+++ b/src/BlazorStrap/Components/Forms/BSInput.cs
@@ -16,7 +16,7 @@ namespace BlazorStrap
     public class BSInput<T> : InputBase<T>
     {
         // Constants
-        private const string _dateFormat = "yyyy-MM-dd";
+        private string _dateFormat = "yyyy-MM-dd";
 
         // Private variables
         private bool _clean = true;
@@ -182,6 +182,9 @@ namespace BlazorStrap
             //Preview 7 workaround
             if (Parent != null)
                 Parent.FormIsReady(MyEditContext);
+
+            if (InputType == InputType.Time)
+                _dateFormat = "HH:mm:ss.fff";
         }
 
         protected override string FormatValueAsString(T value)
@@ -343,7 +346,7 @@ namespace BlazorStrap
             };
         }
 
-        private static bool TryParseDateTime(string value, out T result)
+        private bool TryParseDateTime(string value, out T result)
         {
             var success = BindConverter.TryConvertToDateTime(value, CultureInfo.InvariantCulture, _dateFormat, out DateTime parsedValue);
             if (success)
@@ -358,7 +361,7 @@ namespace BlazorStrap
             }
         }
 
-        private static bool TryParseDateTimeOffset(string value, out T result)
+        private bool TryParseDateTimeOffset(string value, out T result)
         {
             var success = BindConverter.TryConvertToDateTimeOffset(value, CultureInfo.InvariantCulture, _dateFormat, out DateTimeOffset parsedValue);
             if (success)

--- a/src/BlazorStrap/Util/TryParseString.cs
+++ b/src/BlazorStrap/Util/TryParseString.cs
@@ -1,16 +1,34 @@
 ﻿using Microsoft.AspNetCore.Components;
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace BlazorStrap.Util
 {
     public static class TryParseString<T>
     {
-        private const string _dateFormat = "yyyy-MM-dd";
 
-        public static bool ToDateTime(string value, out T result)
+        private static string GetDateTimeFormatString(string value)
         {
-            var success = BindConverter.TryConvertToDateTime(value, CultureInfo.InvariantCulture, _dateFormat, out DateTime parsedValue);
+            const string dateFormat = "yyyy-MM-dd";
+            const string timeFormat = "HH:mm";
+            const string timeFormatWithSeconds = "HH:mm:ss";
+            const string timeFormatWithMilliSeconds = "HH:mm:ss.fff";
+
+            var formatString = value.Count(c => c == ':') switch
+            {
+                1 => timeFormat,
+                2 when value.Contains('.') => timeFormatWithMilliSeconds,
+                2 => timeFormatWithSeconds,
+                _ => dateFormat
+            };
+            return formatString;
+        }
+
+        private static bool ToDateTime(string value, out T result)
+        {
+            var formatString = GetDateTimeFormatString(value);
+            var success = BindConverter.TryConvertToDateTime(value, CultureInfo.InvariantCulture, formatString, out DateTime parsedValue);
             if (success)
             {
                 result = (T)(object)parsedValue;
@@ -25,7 +43,8 @@ namespace BlazorStrap.Util
 
         private static bool ToDateTimeOffset(string value, out T result)
         {
-            var success = BindConverter.TryConvertToDateTimeOffset(value, CultureInfo.InvariantCulture, _dateFormat, out DateTimeOffset parsedValue);
+            var formatString = GetDateTimeFormatString(value);
+            var success = BindConverter.TryConvertToDateTimeOffset(value, CultureInfo.InvariantCulture, formatString, out DateTimeOffset parsedValue);
             if (success)
             {
                 result = (T)(object)parsedValue;

--- a/src/SampleCore/Pages/Samples/InputTime.razor
+++ b/src/SampleCore/Pages/Samples/InputTime.razor
@@ -1,0 +1,32 @@
+﻿@page "/Samples/InputTime"
+@functions {
+    private DateTime TmpDate1 { get; set; } = new DateTime(2020, 06, 23, 22, 50, 10, 780);
+    private DateTime TmpDate2 { get; set; } = new DateTime(2020, 06, 23, 22, 50, 10, 780);
+    private DateTime TmpDate3 { get; set; } = new DateTime(2020, 06, 23, 22, 50, 10, 780);
+}
+<BSForm Model="@TmpDate1">
+    <BSFormGroup IsRow="true">
+        <BSLabel For="time1" SM="4">Without Seconds</BSLabel>
+        <BSCol SM="8">
+            <BSInput InputType="@InputType.Time" Id="time1" @bind-Value="@TmpDate1"></BSInput>
+        </BSCol>
+    </BSFormGroup>
+    <BSFormGroup IsRow="true">
+        <BSLabel For="time2" SM="4">With Seconds</BSLabel>
+        <BSCol SM="8">
+            <BSInput InputType="@InputType.Time" Id="time2" step="1" @bind-Value="@TmpDate2"></BSInput>
+        </BSCol>
+    </BSFormGroup>
+    <BSFormGroup IsRow="true">
+        <BSLabel For="time3" SM="4">With Seconds and MilliSeconds</BSLabel>
+        <BSCol SM="8">
+            <BSInput InputType="@InputType.Time" Id="time3" step="0.001" @bind-Value="@TmpDate3"></BSInput>
+        </BSCol>
+    </BSFormGroup>
+</BSForm>
+
+@(TmpDate1.ToLongTimeString()).@(TmpDate1.Millisecond)
+<br />
+@(TmpDate2.ToLongTimeString()).@(TmpDate2.Millisecond)
+<br />
+@(TmpDate3.ToLongTimeString()).@(TmpDate3.Millisecond)


### PR DESCRIPTION
I needed a way to handle milliseconds and normal Time from BSInput, but noticed, that it currently isn't working at all, because the format pattern for converting in both directions is only specified for Date.

Additionally I noticed, that BSInput.TryParseDateTime and BSInput.TryParseDateTimeOffset aren't used anywhere in the solution (at least I found nothing). Maybe that should be removed, so it doesn't confuse People (like me :))