### PR TITLE
Fix for BSCol for Offset Set to zero

### DIFF
--- a/src/BlazorStrap/Properties/Resources.Designer.cs
+++ b/src/BlazorStrap/Properties/Resources.Designer.cs
@@ -68,7 +68,18 @@ namespace BlazorStrap.Properties {
                 return ResourceManager.GetString("Between 1 and 12", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Must be between 0 and 12.
+        /// </summary>
+        internal static string Between_0_and_12
+        {
+            get
+            {
+                return ResourceManager.GetString("Between 0 and 12", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Must be \&quot;auto\&quot; or between 1 and 12.
         /// </summary>

--- a/src/BlazorStrap/Util/Components/ColumnBase.cs
+++ b/src/BlazorStrap/Util/Components/ColumnBase.cs
@@ -222,9 +222,9 @@ namespace BlazorStrap.Util.Components
 
             set => _xsoffset = (int.TryParse(value, out var ivalue), value?.ToLowerInvariant()) switch
             {
-                (false, _) => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(XSOffset)),
-                (true, var lovalue) when ivalue >= 1 && ivalue <= 12 => lovalue,
-                _ => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(XSOffset))
+                (false, _) => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(XSOffset)),
+                (true, var lovalue) when ivalue >= 0 && ivalue <= 12 => lovalue,
+                _ => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(XSOffset))
             };
         }
 
@@ -236,9 +236,9 @@ namespace BlazorStrap.Util.Components
 
             set => _smoffset = (int.TryParse(value, out var ivalue), value?.ToLowerInvariant()) switch
             {
-                (false, _) => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(SMOffset)),
-                (true, var lovalue) when ivalue >= 1 && ivalue <= 12 => lovalue,
-                _ => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(SMOffset))
+                (false, _) => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(SMOffset)),
+                (true, var lovalue) when ivalue >= 0 && ivalue <= 12 => lovalue,
+                _ => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(SMOffset))
             };
         }
 
@@ -250,9 +250,9 @@ namespace BlazorStrap.Util.Components
 
             set => _mdoffset = (int.TryParse(value, out var ivalue), value?.ToLowerInvariant()) switch
             {
-                (false, _) => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(MDOffset)),
-                (true, var lovalue) when ivalue >= 1 && ivalue <= 12 => lovalue,
-                _ => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(MDOffset))
+                (false, _) => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(MDOffset)),
+                (true, var lovalue) when ivalue >= 0 && ivalue <= 12 => lovalue,
+                _ => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(MDOffset))
             };
         }
 
@@ -264,9 +264,9 @@ namespace BlazorStrap.Util.Components
 
             set => _lgoffset = (int.TryParse(value, out var ivalue), value?.ToLowerInvariant()) switch
             {
-                (false, _) => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(LGOffset)),
-                (true, var lovalue) when ivalue >= 1 && ivalue <= 12 => lovalue,
-                _ => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(LGOffset))
+                (false, _) => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(LGOffset)),
+                (true, var lovalue) when ivalue >= 0 && ivalue <= 12 => lovalue,
+                _ => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(LGOffset))
             };
         }
 
@@ -278,9 +278,9 @@ namespace BlazorStrap.Util.Components
 
             set => _xloffset = (int.TryParse(value, out var ivalue), value?.ToLowerInvariant()) switch
             {
-                (false, _) => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(XLOffset)),
-                (true, var lovalue) when ivalue >= 1 && ivalue <= 12 => lovalue,
-                _ => throw new ArgumentException(Properties.Resources.Between_1_and_12, nameof(XLOffset))
+                (false, _) => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(XLOffset)),
+                (true, var lovalue) when ivalue >= 0 && ivalue <= 12 => lovalue,
+                _ => throw new ArgumentException(Properties.Resources.Between_0_and_12, nameof(XLOffset))
             };
         }
 

--- a/src/SampleCore/Pages/Layout.razor
+++ b/src/SampleCore/Pages/Layout.razor
@@ -104,7 +104,7 @@
             <tr>
                 <td>XSOffset</td>
                 <td>string</td>
-                <td>Must be "1" - "12". offset for xs column</td>
+                <td>Must be "0" - "12". offset for xs column</td>
             </tr>
             <tr>
                 <td>MRAuto</td>
@@ -129,7 +129,7 @@
             <tr>
                 <td>SMOffset</td>
                 <td>string</td>
-                <td>Must be "1" - "12". offset for sm column</td>
+                <td>Must be "0" - "12". offset for sm column</td>
             </tr>
             <tr>
                 <td>SMMRAuto</td>
@@ -154,7 +154,7 @@
             <tr>
                 <td>MDOffset</td>
                 <td>string</td>
-                <td>Must be "1" - "12". offset for md column</td>
+                <td>Must be "0" - "12". offset for md column</td>
             </tr>
             <tr>
                 <td>MDMRAuto</td>
@@ -179,7 +179,7 @@
             <tr>
                 <td>LGOffset</td>
                 <td>string</td>
-                <td>Must be "1" - "12". offset for lg column</td>
+                <td>Must be "0" - "12". offset for lg column</td>
             </tr>
             <tr>
                 <td>LGMRAuto</td>
@@ -204,7 +204,7 @@
             <tr>
                 <td>XLOffset</td>
                 <td>string</td>
-                <td>Must be "1" - "12". offset for xl column</td>
+                <td>Must be "0" - "12". offset for xl column</td>
             </tr>
             <tr>
                 <td>XLMRAuto</td>

--- a/src/SampleCore/Pages/Samples/Issue370.razor
+++ b/src/SampleCore/Pages/Samples/Issue370.razor
@@ -1,0 +1,48 @@
+﻿@page "/samples/issue370"
+
+<BSContainer>
+    <BSRow>
+        <BSCol>.col</BSCol>
+    </BSRow>
+    <BSRow>
+        <BSCol>.col</BSCol>
+        <BSCol>.col</BSCol>
+        <BSCol>.col</BSCol>
+        <BSCol>.col</BSCol>
+    </BSRow>
+    <BSRow>
+        <BSCol XS="3">.col-3</BSCol>
+        <BSCol XS="auto">.col-auto - variable width content</BSCol>
+        <BSCol XS="3">.col-3</BSCol>
+    </BSRow>
+    <BSRow>
+        <BSCol XS="6">.col-6</BSCol>
+        <BSCol XS="6">.col-6</BSCol>
+    </BSRow>
+    <BSRow>
+        <BSCol XS="6" SM="4">.col-6 .col-sm-4</BSCol>
+        <BSCol XS="6" SM="4">.col-6 .col-sm-4</BSCol>
+        <BSCol SM="4">.col-sm-4</BSCol>
+    </BSRow>
+    <BSRow>
+        <BSCol SM="6" SMOrder="2" SMOffset="2">.col-sm-6 .col-sm-order-2 .offset-sm-2</BSCol>
+    </BSRow>
+    <BSRow>
+        <BSCol SM="12" MD="6" MDOffset="3">.col-sm-12 .col-md-6 .offset-md-3</BSCol>
+    </BSRow>
+    <BSRow>
+        <BSCol SM="auto" SMOffset="@offset">.col-sm .offset-sm-1</BSCol>
+        <BSCol SM="auto" SMOffset="@offset">.col-sm .offset-sm-1</BSCol>
+    </BSRow>
+</BSContainer>
+<BSButton OnClick="ChangeOffset">Change Offset to zero</BSButton>
+
+@code {
+    string offset = "1";
+
+    void ChangeOffset(MouseEventArgs e)
+    {
+        offset="0";
+        StateHasChanged();
+    }
+}


### PR DESCRIPTION
This pull request fixes Issue #370 

Allows setting the following offsets to be set to zero. XSOffset, SMOffset, MDOffset, LGOffset, and XLOffset to be set to zero (0). Also updated documentation to reflect this.