### PR TITLE
Eliminate discrepancy between the markup and the docs

### DIFF
--- a/docs/_content/SampleCore/snippets/forms/forms12.html
+++ b/docs/_content/SampleCore/snippets/forms/forms12.html
@@ -15,6 +15,11 @@
             <BSInput InputType="InputType.Text" Id="exampleEmail8" @bind-Value="@formsModelValTT.InValid"/>
             <BSFormFeedback For="@(() => formsModelValTT.InValid)" IsTooltip="true" ValidMessage="Sweet! you fixed the issue"  />
         </BSFormGroup>
+        <BSFormGroup Class="col-md-12">
+            <BSLabel For="exampleDate">Date input</BSLabel>
+            <BSInput InputType="InputType.Date" Id="exampleDate" @bind-Value="@formsModelValTT.Date" />
+            <BSFormFeedback For="@(() => formsModelValTT.Date)" IsTooltip="true" ValidMessage="Sweet! you've chosen the right date" />
+        </BSFormGroup>
     </BSRow>
 </BSForm>
 @code
@@ -28,5 +33,6 @@
         public string InValid { get; set; }
         public string Blank { get; set; }
         public string Email { get; set; } = "email@example.com";
+        public DateTime Date { get; set; }
     }
 }

--- a/src/SampleCore/Pages/Forms.razor
+++ b/src/SampleCore/Pages/Forms.razor
@@ -230,9 +230,9 @@
                 <BSFormFeedback For="@(() => formsModelValTT.InValid)" IsTooltip="true" ValidMessage="Sweet! you fixed the issue" />
             </BSFormGroup>
             <BSFormGroup Class="col-md-12">
-                <BSLabel For="exampleEmail7">Date input</BSLabel>
-                <BSInput InputType="InputType.Date" Id="exampleEmail7" @bind-Value="@formsModelValTT.Date" />
-                <BSFormFeedback For="@(() => formsModelValTT.Date)" IsTooltip="true" ValidMessage="Sweet! that name is available" />
+                <BSLabel For="exampleDate">Date input</BSLabel>
+                <BSInput InputType="InputType.Date" Id="exampleDate" @bind-Value="@formsModelValTT.Date" />
+                <BSFormFeedback For="@(() => formsModelValTT.Date)" IsTooltip="true" ValidMessage="Sweet! you've chosen the right date" />
             </BSFormGroup>
         </BSRow>
     </BSForm>

--- a/src/SampleCore/wwwroot/snippets/forms/forms12.html
+++ b/src/SampleCore/wwwroot/snippets/forms/forms12.html
@@ -15,6 +15,11 @@
             <BSInput InputType="InputType.Text" Id="exampleEmail8" @bind-Value="@formsModelValTT.InValid"/>
             <BSFormFeedback For="@(() => formsModelValTT.InValid)" IsTooltip="true" ValidMessage="Sweet! you fixed the issue"  />
         </BSFormGroup>
+        <BSFormGroup Class="col-md-12">
+            <BSLabel For="exampleDate">Date input</BSLabel>
+            <BSInput InputType="InputType.Date" Id="exampleDate" @bind-Value="@formsModelValTT.Date" />
+            <BSFormFeedback For="@(() => formsModelValTT.Date)" IsTooltip="true" ValidMessage="Sweet! you've chosen the right date" />
+        </BSFormGroup>
     </BSRow>
 </BSForm>
 @code
@@ -28,5 +33,6 @@
         public string InValid { get; set; }
         public string Blank { get; set; }
         public string Email { get; set; } = "email@example.com";
+        public DateTime Date { get; set; }
     }
 }


### PR DESCRIPTION
This is a small PR aligning the documentation with the markup.

**Before:**

![image](https://user-images.githubusercontent.com/19576939/87686795-fe604d00-c795-11ea-93cd-bcb567f6b944.png)


**After:**

![image](https://user-images.githubusercontent.com/19576939/87686955-349dcc80-c796-11ea-8d50-71355d78d31e.png)
