### PR TITLE
Tweak to fix checkboxes

### DIFF
--- a/src/BlazorStrap/Components/Forms/BSBasicInput.cs
+++ b/src/BlazorStrap/Components/Forms/BSBasicInput.cs
@@ -158,7 +158,7 @@ namespace BlazorStrap
             }
             else
             {
-                if (typeof(T) != typeof(bool) || typeof(T) != typeof(bool?))
+                if (typeof(T) != typeof(bool) && typeof(T) != typeof(bool?))
                 {
                     if (CheckValue != null)
                     {


### PR DESCRIPTION
Looks like in the recent changes for nullable bools a `||` was used instead of a `&&` which prevent ordinary checkboxes from binding correctly (the bound variable wasn't updating from false).