### PR TITLE
Same change as #396 for BSInput

### DIFF
--- a/src/BlazorStrap/Components/Forms/BSInput.cs
+++ b/src/BlazorStrap/Components/Forms/BSInput.cs
@@ -280,7 +280,7 @@ namespace BlazorStrap
             }
             else
             {
-                if (typeof(T) != typeof(bool) || typeof(T) != typeof(bool?))
+                if (typeof(T) != typeof(bool) && typeof(T) != typeof(bool?))
                 {
                     if (CheckValue != null)
                     {


### PR DESCRIPTION
#396 was for BSBasicInput, this for BSInput.

Looks like in the recent changes for nullable bools a `||` was used instead of a `&&` which prevent ordinary checkboxes from binding correctly (the bound variable wasn't updating from false).

BSInput reproduction example

```
@page "/"

<h1>Hello, world!</h1>

<div>
    <BSForm Model="ViewModel">
        <BSFormGroup IsCheck="true">
            <BSInput name="test" id="test" InputType="InputType.Checkbox" @bind-Value="ViewModel.Test" />
            <BSLabel IsCheck="true" For="test">Click</BSLabel>
        </BSFormGroup>
    </BSForm>
    <div>
        @(ViewModel.Test ? "Yes": "No")
    </div>
</div>

@code {
    private Model ViewModel { get; set; } = new Model();

    public class Model
    {
        public bool Test { get; set; }
    }
}
```