### PR TITLE
Target net5.0 and netstandard2.x and set either EditForm's Model or EditContext 

### DIFF
--- a/BlazorStrap.Tests/BlazorStrap.Tests.csproj
+++ b/BlazorStrap.Tests/BlazorStrap.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/BlazorStrap.Extensions.BSDataTable/BlazorStrap.Extensions.BSDataTable.csproj
+++ b/src/BlazorStrap.Extensions.BSDataTable/BlazorStrap.Extensions.BSDataTable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-	  <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
 	  <RazorLangVersion>3.0</RazorLangVersion>
 	  <PackageId>BlazorStrap.Extensions.BSDataTable</PackageId>
 	  <Version>1.0.1-Preview-01</Version>
@@ -14,7 +14,11 @@
   </PropertyGroup>
 
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0-rc.1.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
   </ItemGroup>

--- a/src/BlazorStrap.Extensions.FluentValidation/BlazorStrap.Extensions.FluentValidation.csproj
+++ b/src/BlazorStrap.Extensions.FluentValidation/BlazorStrap.Extensions.FluentValidation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <LangVersion>8.0</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
@@ -19,9 +19,14 @@
     <AssemblyName>BlazorStrap.Extensions.FluentValidation</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0-rc.1.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.6.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/BlazorStrap.Extensions.SvgLoader/BlazorStrap.Extensions.SvgLoader.csproj
+++ b/src/BlazorStrap.Extensions.SvgLoader/BlazorStrap.Extensions.SvgLoader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
 	  <PackageId>BlazorStrap.Extensions.SVGLoader</PackageId>
 	  <Version>1.0.0</Version>
@@ -13,9 +13,15 @@
   </PropertyGroup>
 
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0-rc.1.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="BlazorComponentUtilities" Version="1.6.0" />
   </ItemGroup>
 

--- a/src/BlazorStrap.Extensions.TreeView/BlazorStrap.Extensions.TreeView.csproj
+++ b/src/BlazorStrap.Extensions.TreeView/BlazorStrap.Extensions.TreeView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
     <PackageId>BlazorStrap.Extensions.TreeView</PackageId>
     <Version>1.0.5</Version>
@@ -15,7 +15,11 @@
   </PropertyGroup>
 
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0-rc.1.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
   </ItemGroup>

--- a/src/BlazorStrap/BlazorStrap.csproj
+++ b/src/BlazorStrap/BlazorStrap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <LangVersion>8.0</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
@@ -17,9 +17,14 @@
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0-preview.9.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BlazorComponentUtilities" Version="1.6.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorStrap/Components/Forms/BSForm.cs
+++ b/src/BlazorStrap/Components/Forms/BSForm.cs
@@ -46,12 +46,18 @@ namespace BlazorStrap
                 Formbuilder.OpenComponent<EditForm>(0);
                 Formbuilder.AddMultipleAttributes(1, AdditionalAttributes);
                 Formbuilder.AddAttribute(2, "class", Classname);
-                Formbuilder.AddAttribute(3, "Model", Model);
-                Formbuilder.AddAttribute(4, "EditContext", EditContext);
-                Formbuilder.AddAttribute(5, "OnSubmit", OnSubmit);
-                Formbuilder.AddAttribute(6, "OnValidSubmit", OnValidSubmit);
-                Formbuilder.AddAttribute(7, "OnInvalidSubmit", OnInvalidSubmit);
-                Formbuilder.AddAttribute(8, "ChildContent", ChildContent);
+                if (EditContext != null)
+                {
+                    Formbuilder.AddAttribute(3, "EditContext", EditContext);
+                }
+                else 
+                { 
+                    Formbuilder.AddAttribute(3, "Model", Model);
+                }
+                Formbuilder.AddAttribute(4, "OnSubmit", OnSubmit);
+                Formbuilder.AddAttribute(5, "OnValidSubmit", OnValidSubmit);
+                Formbuilder.AddAttribute(6, "OnInvalidSubmit", OnInvalidSubmit);
+                Formbuilder.AddAttribute(7, "ChildContent", ChildContent);
                 Formbuilder.CloseComponent();
             };
 

--- a/src/BlazorStrap/Properties/Resources.Designer.cs
+++ b/src/BlazorStrap/Properties/Resources.Designer.cs
@@ -61,25 +61,14 @@ namespace BlazorStrap.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Must be between 1 and 12.
-        /// </summary>
-        internal static string Between_1_and_12 {
-            get {
-                return ResourceManager.GetString("Between 1 and 12", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Must be between 0 and 12.
         /// </summary>
-        internal static string Between_0_and_12
-        {
-            get
-            {
+        internal static string Between_0_and_12 {
+            get {
                 return ResourceManager.GetString("Between 0 and 12", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Must be \&quot;auto\&quot; or between 1 and 12.
         /// </summary>

--- a/src/BlazorStrap/Properties/Resources.resx
+++ b/src/BlazorStrap/Properties/Resources.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Between 1 and 12" xml:space="preserve">
-    <value>Must be between 1 and 12</value>
+  <data name="Between 0 and 12" xml:space="preserve">
+    <value>Must be between 0 and 12</value>
   </data>
   <data name="Between 1 and 12 Auto" xml:space="preserve">
     <value>Must be \"auto\" or between 1 and 12</value>

--- a/src/Sample/ClientSideSample.csproj
+++ b/src/Sample/ClientSideSample.csproj
@@ -1,13 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <RazorLangVersion>3.0</RazorLangVersion>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-rc.1.*" />
+    <!--<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="5.0.0-rc.1.*" />-->
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0-rc.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-rc.1.*" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />

--- a/src/SampleCore/SampleCore.csproj
+++ b/src/SampleCore/SampleCore.csproj
@@ -1,13 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.0-rc.1.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.4" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BlazorPrettyCode" Version="1.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServerSideSample/ServerSideSample.csproj
+++ b/src/ServerSideSample/ServerSideSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #399 and follows up on fixing a missing generated resource from #372 since that file was either omitted from commit or manually edited.

This PR attempts to target both net5.0-rc1 packages and netcore3.1.x packages