### PR TITLE
Fix for #423

### DIFF
--- a/src/BlazorStrap/wwwroot/blazorStrap.js
+++ b/src/BlazorStrap/wwwroot/blazorStrap.js
@@ -198,9 +198,11 @@ window.blazorStrap = {
     },
 
     collapsingElementEnd: function (element) {
-        element.style.height = "";
-        element.classList.remove("collapsing");
-        element.classList.add("collapse");
+        if (element) {
+            element.style.height = "";
+            element.classList.remove("collapsing");
+            element.classList.add("collapse");
+        }
         return true;
     },
     setBootstrapCss: function (theme, version) {


### PR DESCRIPTION
#423 Wrap the contents of `collapsingElementEnd` in `if (element) {}` so that if the element already has been destroyed in the DOM, an error will not occur.