### PR TITLE
Fix null reference when dropdown menu is used with  BSNav / BSNavItem

### DIFF
--- a/src/BlazorStrap/Components/Dropdown/BSDropdownItem.razor.cs
+++ b/src/BlazorStrap/Components/Dropdown/BSDropdownItem.razor.cs
@@ -38,6 +38,7 @@ namespace BlazorStrap
         [Parameter] public string Class { get; set; }
         [Parameter] public RenderFragment ChildContent { get; set; }
         [CascadingParameter] internal BSDropdown DropDown { get; set; }
+        [CascadingParameter] internal BSNavItem NavItem { get; set; }
 
         protected void OnClickEvent(MouseEventArgs e)
         {
@@ -50,7 +51,13 @@ namespace BlazorStrap
             //   {
             if (!StayOpen)
             {
-                DropDown.Selected = null;
+                if (DropDown != null) {
+                    DropDown.Selected = null;
+                }
+
+                if (NavItem != null) {
+                    NavItem.Selected = null;
+                }
             }
             //  }
         }


### PR DESCRIPTION
Observed null reference when the dropdown menu was used without the BSDropdown.
```
 <BSNav IsList="true" IsNavbar="true">
                <BSNavItem IsDropdown="true" @bind-IsOpen="@isFeature1MenuOpen
                    <BSDropdownToggle IsLink="true" @onclick="OnClickFeature1" Class="text-white">Feature1<BSDropdownToggle>
                    <BSDropdownMenu @bind-IsOpen="@isFeature1MenuOpen">
                        <BSDropdownItem Href="item1" @onclick="OnClickFeature1">Item1</BSDropdownItem>
..
                    </BSDropdownMenu>
                </BSNavItem>
</BSNav>
```