### PR TITLE
Update code samples for Themes docs

### DIFF
--- a/src/SampleCore/wwwroot/snippets/themes/themes1.html
+++ b/src/SampleCore/wwwroot/snippets/themes/themes1.html
@@ -2,7 +2,7 @@
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddBootstrapCSS();
+        services.AddBootstrapCss();
     }
 
     public void Configure(IComponentsApplicationBuilder app)

--- a/src/SampleCore/wwwroot/snippets/themes/themes2.html
+++ b/src/SampleCore/wwwroot/snippets/themes/themes2.html
@@ -1,5 +1,5 @@
 ﻿@inherits LayoutComponentBase
-@inject IBootstrapCSS BootstrapCSS
+@inject IBootstrapCss BootstrapCss
 
 <div class="sidebar" style="overflow-y: auto">
     <NavMenu />
@@ -12,6 +12,6 @@
 @code {
     protected override async Task OnInitAsync()
     {
-        await BootstrapCSS.SetBootstrapCSS("4.3.1");
+        await BootstrapCSS.SetBootstrapCss("4.3.1");
     }
 }

--- a/src/SampleCore/wwwroot/snippets/themes/themes3.html
+++ b/src/SampleCore/wwwroot/snippets/themes/themes3.html
@@ -13,7 +13,7 @@
     {
         services.AddRazorPages();
         services.AddServerSideBlazor();
-        services.AddBootstrapCSS();
+        services.AddBootstrapCss();
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/SampleCore/wwwroot/snippets/themes/themes4.html
+++ b/src/SampleCore/wwwroot/snippets/themes/themes4.html
@@ -1,5 +1,5 @@
 ﻿@inherits LayoutComponentBase
-@inject IBootstrapCSS BootstrapCSS
+@inject IBootstrapCss BootstrapCss
 
 <div class="sidebar" style="overflow-y: auto">
     <NavMenu />
@@ -16,7 +16,7 @@
     {
         if (isServerSide && !hasBeendone)
         {
-            await BootstrapCSS.SetBootstrapCSS("4.3.1");
+            await BootstrapCss.SetBootstrapCss("4.3.1");
             hasBeendone = true;
         }
     }

--- a/src/SampleCore/wwwroot/snippets/themes/themes5.html
+++ b/src/SampleCore/wwwroot/snippets/themes/themes5.html
@@ -1,4 +1,4 @@
-﻿@inject IBootstrapCSS BootstrapCSS
+﻿@inject IBootstrapCss BootstrapCss
 
 <BlazorForm>
     <BlazorInput InputType="InputType.Select" Value="@Selected" ValueChanged="@SelectedChanged">
@@ -17,13 +17,13 @@
     private async void SelectedChanged(string value)
     {
         Selected = value;
-        await BootstrapCSS.SetBootstrapCSS(value, "4.3.1");
+        await BootstrapCSS.SetBootstrapCss(value, "4.3.1");
     }
 
 
     protected override void OnInit()
     {
         themes = Enum.GetNames(typeof(Theme)).ToList();
-        Selected = BootstrapCSS.CurrentTheme.ToString();
+        Selected = BootstrapCss.CurrentTheme.ToString();
     }
 }


### PR DESCRIPTION
Currently the step-by-step for Themes provides the 'Css' version however the code samples then go on to use the 'CSS' version.

This change will make them consistent (and my impression is the 'Css' version is considered more proper now)