### PR TITLE
Carousel updates

### DIFF
--- a/src/BlazorStrap/Components/Carousel/BSCarousel.razor.cs
+++ b/src/BlazorStrap/Components/Carousel/BSCarousel.razor.cs
@@ -166,6 +166,7 @@ namespace BlazorStrap
                 await ActiveIndexChangedEvent.InvokeAsync(ActiveIndex).ConfigureAwait(false);
             }
         }
+
         protected async Task OnKeyPress(KeyboardEventArgs e)
         {
             if (!Keyboard) return;
@@ -232,7 +233,6 @@ namespace BlazorStrap
         {
             if (AnimationRunning) return;
             ResetTimer();
-
             ActiveIndex = ActiveIndex == 0 ? NumberOfItems - 1 : ActiveIndex - 1;
             await DoAnimations().ConfigureAwait(true);
         }

--- a/src/BlazorStrap/Components/Carousel/BSCarousel.razor.cs
+++ b/src/BlazorStrap/Components/Carousel/BSCarousel.razor.cs
@@ -57,7 +57,7 @@ namespace BlazorStrap
         [Parameter] public bool Touch { get; set; } = true;
         [Parameter(CaptureUnmatchedValues = true)] public IDictionary<string, object> UnknownParameters { get; set; }
         [Parameter] public bool Wrap { get; set; } = true;
-        [Parameter] public EventCallback<int> ActiveIndexChanged { get; set; }
+        [Parameter] public EventCallback<int> ActiveIndexChangedEvent { get; set; }
         internal int Direction { get; set; }
 
         protected string Classname => new CssBuilder("carousel slide")
@@ -163,7 +163,7 @@ namespace BlazorStrap
                 if (_timerEnabled)
                     Timer.Start();
 
-                await ActiveIndexChanged.InvokeAsync(ActiveIndex).ConfigureAwait(false);
+                await ActiveIndexChangedEvent.InvokeAsync(ActiveIndex).ConfigureAwait(false);
             }
         }
         protected async Task OnKeyPress(KeyboardEventArgs e)

--- a/src/BlazorStrap/Components/Carousel/BSCarouselControl.razor.cs
+++ b/src/BlazorStrap/Components/Carousel/BSCarouselControl.razor.cs
@@ -24,11 +24,9 @@ namespace BlazorStrap
 
         protected string DirectionName => CarouselDirection == CarouselDirection.Previous ? "Previous" : "Next";
 
-        [Parameter] public int NumberOfItems { get; set; }
         [Parameter] public CarouselDirection CarouselDirection { get; set; } = CarouselDirection.Previous;
         [Parameter] public string Class { get; set; }
         [CascadingParameter] internal BSCarousel Parent { get; set; }
-
         [Parameter] public EventCallback<int> ActiveIndexChanged { get; set; }
 
         protected async Task OnClick()
@@ -36,17 +34,13 @@ namespace BlazorStrap
             if (Parent.AnimationRunning) return;
             if (CarouselDirection == CarouselDirection.Previous)
             {
-                Parent.Direction = 1;
-                Parent.ResetTimer();
-                Parent.ActiveIndex = Parent.ActiveIndex == 0 ? NumberOfItems - 1 : Parent.ActiveIndex - 1;
+                await Parent.GoToPrevItem().ConfigureAwait(true);
             }
             else
             {
-                Parent.Direction = 0;
-                Parent.ResetTimer();
-                Parent.ActiveIndex = Parent.ActiveIndex == NumberOfItems - 1 ? 0 : Parent.ActiveIndex + 1;
+                await Parent.GoToNextItem().ConfigureAwait(true);
             }
-            await ActiveIndexChanged.InvokeAsync(Parent.ActiveIndex).ConfigureAwait(false);
+            await ActiveIndexChanged.InvokeAsync(Parent.ActiveIndex).ConfigureAwait(true);
         }
     }
 }

--- a/src/BlazorStrap/Components/Carousel/BSCarouselIndicatorItem.razor.cs
+++ b/src/BlazorStrap/Components/Carousel/BSCarouselIndicatorItem.razor.cs
@@ -26,7 +26,8 @@ namespace BlazorStrap
 
         protected async Task OnClick()
         {
-            await ActiveIndexChangedEvent.InvokeAsync(Index).ConfigureAwait(false);
+            await Parent.GoToSpecificItem(Index).ConfigureAwait(true);
+            await ActiveIndexChangedEvent.InvokeAsync(Index).ConfigureAwait(true);
         }
     }
 }

--- a/src/BlazorStrap/Components/Carousel/BSCarouselIndicators.razor
+++ b/src/BlazorStrap/Components/Carousel/BSCarouselIndicators.razor
@@ -1,7 +1,7 @@
 ﻿@namespace BlazorStrap
 
 <DynamicElement @attributes="@UnknownParameters" TagName="ol" class="@Classname">
-    @for (var i = 0; i < NumberOfItems; i++)
+    @for (var i = 0; i < _numberOfItems; i++)
     {
         <BSCarouselIndicatorItem IsActive="@(i == ActiveIndex)" Index="@i" ActiveIndexChangedEvent="@ClickEventActiveIndex" />
     }

--- a/src/BlazorStrap/Components/Carousel/BSCarouselIndicators.razor.cs
+++ b/src/BlazorStrap/Components/Carousel/BSCarouselIndicators.razor.cs
@@ -7,18 +7,19 @@ namespace BlazorStrap
     public partial class BSCarouselIndicators : ComponentBase
     {
         [Parameter(CaptureUnmatchedValues = true)] public IDictionary<string, object> UnknownParameters { get; set; }
+        [CascadingParameter] protected BSCarousel Parent { get; set; }
 
         protected string Classname =>
         new CssBuilder("carousel-indicators")
         .AddClass(Class)
         .Build();
 
-        [Parameter] public int NumberOfItems { get; set; }
         [Parameter] public int ActiveIndex { get; set; }
         [Parameter] public string Class { get; set; }
         [Parameter] public RenderFragment ChildContent { get; set; }
         [Parameter] public EventCallback<int> ActiveIndexChanged { get; set; }
         [Parameter] public EventCallback<int> ActiveIndexChangedEvent { get; set; }
+        private int _numberOfItems { get => Parent.NumberOfItems; }
 
         protected void ClickEventActiveIndex(int index)
         {

--- a/src/BlazorStrap/Components/Carousel/BSCarouselItem.razor.cs
+++ b/src/BlazorStrap/Components/Carousel/BSCarouselItem.razor.cs
@@ -42,15 +42,15 @@ namespace BlazorStrap
         [Parameter] public string ActionLinkTarget { get; set; } = "_self";
         [Parameter] public RenderFragment ChildContent { get; set; }
 
+        protected override Task OnParametersSetAsync()
+        {
+            return base.OnParametersSetAsync();
+        }
+
         protected override void OnInitialized()
         {
             SetSvg();
             Parent.CarouselItems.Add(this);
-        }
-
-        public async Task StateChanged()
-        {
-            await InvokeAsync(StateHasChanged).ConfigureAwait(false);
         }
 
         public Task AnimationEnd()
@@ -65,19 +65,17 @@ namespace BlazorStrap
                 if(Parent.CarouselItems[0] == this)
                 {
                     Active = true;
-                    await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+                    await InvokeAsync(StateHasChanged).ConfigureAwait(true);
                 }
             }
         }
-        public Task Clean()
+        public void Clean()
         {
             Active = false;
             Left = false;
             Right = false;
             Prev = false;
             Next = false;
-
-            return Task.CompletedTask;
         }
 
         private void SetSvg()

--- a/src/SampleCore/Pages/Carousels.razor
+++ b/src/SampleCore/Pages/Carousels.razor
@@ -1,90 +1,121 @@
 ﻿@page "/carousels"
 
+<button @onclick="@(() => items.Add(items.First()))">Add Item</button>
+
 <h1>Carousels</h1>
+
+
+<BSButton Color="Color.Primary" @onclick="@(() => ImageCarouselModal.Show())">Launch demo modal</BSButton>
+<BSModal @ref="ImageCarouselModal">
+    <BSModalHeader OnClick="@(() => ImageCarouselModal.Hide())">Exterior Images</BSModalHeader>
+    <BSModalBody>
+        @if (ImageCarouselModal.IsOpen == true)
+        {
+            <BSCarousel NumberOfItems="@items.Count">
+                <BSCarouselIndicators/>
+                <div class="carousel-inner">
+                    @for (int i = 0; i < items.Count; i++)
+                    {
+                        <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" />
+                    }
+                </div>
+                <BSCarouselControl CarouselDirection="CarouselDirection.Previous" ActiveIndexChanged="@(newIndex => { return; })"/>
+                <BSCarouselControl CarouselDirection="CarouselDirection.Next" ActiveIndexChanged="@(newIndex => { return; })" />
+            </BSCarousel>
+        }
+
+    </BSModalBody>
+    <BSModalFooter>
+    </BSModalFooter>
+</BSModal>
 
 <div class="docs-example">
     <BSCarousel NumberOfItems="@items.Count">
-        <BSCarouselIndicators NumberOfItems="@items.Count" />
+        <BSCarouselIndicators />
         <div class="carousel-inner">
             @for (int i = 0; i < items.Count; i++)
             {
                 <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" />
             }
         </div>
-        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@items.Count" />
-        <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@items.Count" />
+        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+        <BSCarouselControl CarouselDirection="CarouselDirection.Next" />
     </BSCarousel>
 </div>
 <PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels1.html" />
 <h3>With Captions & Headers & Fade</h3>
 
-<div class="docs-example">
-    <BSCarousel NumberOfItems="@items.Count" Fade="true">
-        <BSCarouselIndicators NumberOfItems="@items.Count" ActiveIndexChangedEvent="@indexChanged" />
-        <div class="carousel-inner">
-            @for (int i = 0; i < items.Count; i++)
-            {
-                Item item = items[i];
-                <BSCarouselItem src="@item.Source" alt="@item.Alt">
-                    <BSCarouselCaption CaptionText="@item.Caption" HeaderText="@item.Header" />
-                </BSCarouselItem>
-            }
-        </div>
-        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@items.Count" />
-        <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@items.Count" />
-    </BSCarousel>
-</div>
-<PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels2.html" />
+    <div class="docs-example">
+        <BSCarousel NumberOfItems="@items.Count" Fade="true">
+            <BSCarouselIndicators ActiveIndexChangedEvent="@indexChanged" />
+            <div class="carousel-inner">
+                @for (int i = 0; i < items.Count; i++)
+                {
+                    Item item = items[i];
+                    <BSCarouselItem src="@item.Source" alt="@item.Alt">
+                        <BSCarouselCaption CaptionText="@item.Caption" HeaderText="@item.Header" />
+                    </BSCarouselItem>
+                }
+            </div>
+            <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+            <BSCarouselControl CarouselDirection="CarouselDirection.Next"  />
+        </BSCarousel>
+    </div>
+    <PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels2.html" />
 
-<h3>With Clickable Image</h3>
+    <h3>With Clickable Image</h3>
 
-<div class="docs-example">
-    <BSCarousel NumberOfItems="@items.Count">
-        <BSCarouselIndicators NumberOfItems="@items.Count" />
-        <div class="carousel-inner">
-            @for (int i = 0; i < items.Count; i++)
-            {
-                <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" ActionLink="@items[i].ActionLink" ActionLinkTarget="@items[i].ActionLinkTarget" />
-            }
-        </div>
-        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@items.Count" />
-        <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@items.Count" />
-    </BSCarousel>
-</div>
-<PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels3.html" />
+    <div class="docs-example">
+        <BSCarousel NumberOfItems="@items.Count">
+            <BSCarouselIndicators />
+            <div class="carousel-inner">
+                @for (int i = 0; i < items.Count; i++)
+                {
+                    <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" ActionLink="@items[i].ActionLink" ActionLinkTarget="@items[i].ActionLinkTarget" />
+                }
+            </div>
+            <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+            <BSCarouselControl CarouselDirection="CarouselDirection.Next" />
+        </BSCarousel>
+    </div>
+    <PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels3.html" />
 
-<h3>With Svg's instead of an Image</h3>
+    <h3>With Svg's instead of an Image</h3>
 
-<BSAlert Color="Color.Info">
-    In order to use the BSSvg component you will need to register a service. See <a href="/svgs">Svg's</a> for setup instructions.
-</BSAlert>
+    <BSAlert Color="Color.Info">
+        In order to use the BSSvg component you will need to register a service. See <a href="/svgs">Svg's</a> for setup instructions.
+    </BSAlert>
 
-<div class="docs-example">
-    <BSCarousel NumberOfItems="@svgItems.Count">
-        <BSCarouselIndicators NumberOfItems="@svgItems.Count" />
-        <div class="carousel-inner">
-            @for (int i = 0; i < svgItems.Count; i++)
-            {
-                <BSCarouselItem src="@svgItems[i].Source" alt="@svgItems[i].Alt" ActionLink="@svgItems[i].ActionLink" ActionLinkTarget="@svgItems[i].ActionLinkTarget" />
-            }
-        </div>
-        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@svgItems.Count" />
-        <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@svgItems.Count" />
-    </BSCarousel>
-</div>
-<PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels4.html" />
+    <div class="docs-example">
+        <BSCarousel NumberOfItems="@svgItems.Count">
+            <BSCarouselIndicators />
+            <div class="carousel-inner">
+                @for (int i = 0; i < svgItems.Count; i++)
+                {
+                    <BSCarouselItem src="@svgItems[i].Source" alt="@svgItems[i].Alt" ActionLink="@svgItems[i].ActionLink" ActionLinkTarget="@svgItems[i].ActionLinkTarget" />
+                }
+            </div>
+            <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+            <BSCarouselControl CarouselDirection="CarouselDirection.Next" />
+        </BSCarousel>
+    </div>
+    <PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels4.html" />
 
-<h3>Using the Carousel Data Template</h3>
-<div class="docs-example">
-    <BSDataCarousel Items="items" Context="item" HasControls="true" HasIndicators="true">
-        <ItemTemplate>
-            <BSCarouselItem src="@item.Source" alt="@item.Alt" ActionLink="@item.ActionLink" ActionLinkTarget="@item.ActionLinkTarget" />
-        </ItemTemplate>
-    </BSDataCarousel>
-</div>
-<PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels5.html" />
+    <h3>Using the Carousel Data Template</h3>
+    <div class="docs-example">
+        <BSDataCarousel Items="items" Context="item" HasControls="true" HasIndicators="true">
+            <ItemTemplate>
+                <BSCarouselItem src="@item.Source" alt="@item.Alt" ActionLink="@item.ActionLink" ActionLinkTarget="@item.ActionLinkTarget" />
+            </ItemTemplate>
+        </BSDataCarousel>
+    </div>
+    <PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels5.html" />
 
 @code {
+
+    BSModal ImageCarouselModal { get; set; }
+
+
     List<Item> items = new List<Item>
 {
         new Item {

--- a/src/SampleCore/Pages/Carousels.razor
+++ b/src/SampleCore/Pages/Carousels.razor
@@ -1,36 +1,9 @@
 ﻿@page "/carousels"
 
-<button @onclick="@(() => items.Add(items.First()))">Add Item</button>
-
 <h1>Carousels</h1>
 
-
-<BSButton Color="Color.Primary" @onclick="@(() => ImageCarouselModal.Show())">Launch demo modal</BSButton>
-<BSModal @ref="ImageCarouselModal">
-    <BSModalHeader OnClick="@(() => ImageCarouselModal.Hide())">Exterior Images</BSModalHeader>
-    <BSModalBody>
-        @if (ImageCarouselModal.IsOpen == true)
-        {
-            <BSCarousel NumberOfItems="@items.Count">
-                <BSCarouselIndicators/>
-                <div class="carousel-inner">
-                    @for (int i = 0; i < items.Count; i++)
-                    {
-                        <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" />
-                    }
-                </div>
-                <BSCarouselControl CarouselDirection="CarouselDirection.Previous" ActiveIndexChanged="@(newIndex => { return; })"/>
-                <BSCarouselControl CarouselDirection="CarouselDirection.Next" ActiveIndexChanged="@(newIndex => { return; })" />
-            </BSCarousel>
-        }
-
-    </BSModalBody>
-    <BSModalFooter>
-    </BSModalFooter>
-</BSModal>
-
 <div class="docs-example">
-    <BSCarousel NumberOfItems="@items.Count">
+    <BSCarousel NumberOfItems="@items.Count" ActiveIndexChangedEvent="@indexChanged">
         <BSCarouselIndicators />
         <div class="carousel-inner">
             @for (int i = 0; i < items.Count; i++)
@@ -112,9 +85,6 @@
     <PrettyCode CodeFile="_content/SampleCore/snippets/carousels/carousels5.html" />
 
 @code {
-
-    BSModal ImageCarouselModal { get; set; }
-
 
     List<Item> items = new List<Item>
 {

--- a/src/SampleCore/wwwroot/snippets/carousels/carousels1.html
+++ b/src/SampleCore/wwwroot/snippets/carousels/carousels1.html
@@ -1,9 +1,9 @@
-﻿<BSCarousel NumberOfItems="@items.Count">
-    <BSCarouselIndicators NumberOfItems="@items.Count" ActiveIndexChangedEvent="@indexChanged"/>
+﻿<BSCarousel NumberOfItems="@items.Count" ActiveIndexChangedEvent="@indexChanged">
+    <BSCarouselIndicators />
     <div class="carousel-inner">
         @for (int i = 0; i < items.Count; i++)
         {
-            <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" />
+        <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" />
         }
     </div>
     <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />

--- a/src/SampleCore/wwwroot/snippets/carousels/carousels1.html
+++ b/src/SampleCore/wwwroot/snippets/carousels/carousels1.html
@@ -1,14 +1,14 @@
 ﻿<BSCarousel NumberOfItems="@items.Count">
-        <BSCarouselIndicators NumberOfItems="@items.Count" />
-        <div class="carousel-inner">
-            @for (int i = 0; i < items.Count; i++)
-            {
-                <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" />
-            }
-        </div>
-        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@items.Count" />
-        <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@items.Count" />
-    </BSCarousel>
+    <BSCarouselIndicators NumberOfItems="@items.Count" ActiveIndexChangedEvent="@indexChanged"/>
+    <div class="carousel-inner">
+        @for (int i = 0; i < items.Count; i++)
+        {
+            <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" />
+        }
+    </div>
+    <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+    <BSCarouselControl CarouselDirection="CarouselDirection.Next" />
+</BSCarousel>
     
 @code {
     IList<Item> items = new List<Item>

--- a/src/SampleCore/wwwroot/snippets/carousels/carousels2.html
+++ b/src/SampleCore/wwwroot/snippets/carousels/carousels2.html
@@ -1,17 +1,17 @@
-﻿ <BSCarousel NumberOfItems="@items.Count" Fade="true">
-        <BSCarouselIndicators NumberOfItems="@items.Count" ActiveIndexChangedEvent="@indexChanged" />
-        <div class="carousel-inner">
-            @for (int i = 0; i < items.Count; i++)
-            {
-                Item item = items[i];
-                <BSCarouselItem src="@item.Source" alt="@item.Alt">
-                    <BSCarouselCaption CaptionText="@item.Caption" HeaderText="@item.Header" />
-                </BSCarouselItem>
-            }
-        </div>
-        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@items.Count" />
-        <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@items.Count" />
-    </BSCarousel>
+﻿<BSCarousel NumberOfItems="@items.Count" Fade="true">
+    <BSCarouselIndicators ActiveIndexChangedEvent="@indexChanged" />
+    <div class="carousel-inner">
+        @for (int i = 0; i < items.Count; i++)
+        {
+        Item item = items[i];
+        <BSCarouselItem src="@item.Source" alt="@item.Alt">
+            <BSCarouselCaption CaptionText="@item.Caption" HeaderText="@item.Header" />
+        </BSCarouselItem>
+        }
+    </div>
+    <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+    <BSCarouselControl CarouselDirection="CarouselDirection.Next" />
+</BSCarousel>
     
 @code {
     int i = 0;
@@ -43,5 +43,10 @@
         public string Alt { get; set; }
         public string Caption { get; set; }
         public string Header { get; set; }
+    }
+
+    private void indexChanged(int index)
+    {
+        Console.WriteLine("Index Changed: " + index);
     }
 }

--- a/src/SampleCore/wwwroot/snippets/carousels/carousels3.html
+++ b/src/SampleCore/wwwroot/snippets/carousels/carousels3.html
@@ -1,14 +1,14 @@
-﻿    <BSCarousel NumberOfItems="@items.Count">
-        <BSCarouselIndicators NumberOfItems="@items.Count" />
-        <div class="carousel-inner">
-            @for (int i = 0; i < items.Count; i++)
-            {
-                <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" ActionLink="@items[i].ActionLink" ActionLinkTarget="@items[i].ActionLinkTarget" />
-            }
-        </div>
-        <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@items.Count" />
-        <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@items.Count" />
-    </BSCarousel>
+﻿<BSCarousel NumberOfItems="@items.Count">
+    <BSCarouselIndicators />
+    <div class="carousel-inner">
+        @for (int i = 0; i < items.Count; i++)
+        {
+        <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" ActionLink="@items[i].ActionLink" ActionLinkTarget="@items[i].ActionLinkTarget" />
+        }
+    </div>
+    <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+    <BSCarouselControl CarouselDirection="CarouselDirection.Next" />
+</BSCarousel>
 
 @code {
     int i = 0;

--- a/src/SampleCore/wwwroot/snippets/carousels/carousels4.html
+++ b/src/SampleCore/wwwroot/snippets/carousels/carousels4.html
@@ -1,13 +1,13 @@
-﻿<BSCarousel NumberOfItems="@items.Count">
-    <BSCarouselIndicators NumberOfItems="@items.Count" />
+﻿<BSCarousel NumberOfItems="@svgItems.Count">
+    <BSCarouselIndicators />
     <div class="carousel-inner">
-        @for (int i = 0; i < items.Count; i++)
+        @for (int i = 0; i < svgItems.Count; i++)
         {
-        <BSCarouselItem src="@items[i].Source" alt="@items[i].Alt" ActionLink="@items[i].ActionLink" ActionLinkTarget="@items[i].ActionLinkTarget" />
+        <BSCarouselItem src="@svgItems[i].Source" alt="@svgItems[i].Alt" ActionLink="@svgItems[i].ActionLink" ActionLinkTarget="@svgItems[i].ActionLinkTarget" />
         }
     </div>
-    <BSCarouselControl CarouselDirection="CarouselDirection.Previous" NumberOfItems="@items.Count" />
-    <BSCarouselControl CarouselDirection="CarouselDirection.Next" NumberOfItems="@items.Count" />
+    <BSCarouselControl CarouselDirection="CarouselDirection.Previous" />
+    <BSCarouselControl CarouselDirection="CarouselDirection.Next" />
 </BSCarousel>
     
 @code {

--- a/src/SampleCore/wwwroot/snippets/carousels/carousels5.html
+++ b/src/SampleCore/wwwroot/snippets/carousels/carousels5.html
@@ -1,4 +1,4 @@
-﻿<BSDataCarousel Items="items" HasControls="true" HasIndicators="true" Context="item">
+﻿<BSDataCarousel Items="items" Context="item" HasControls="true" HasIndicators="true">
     <ItemTemplate>
         <BSCarouselItem src="@item.Source" alt="@item.Alt" ActionLink="@item.ActionLink" ActionLinkTarget="@item.ActionLinkTarget" />
     </ItemTemplate>


### PR DESCRIPTION
Hello!

Lots of updates for the carousel component here. This was all spawned by an exception caused when the parent of a carousel component re-rendered while the carousel was in the middle of an animation. I found this by subscribing to the ActiveIndexChanged event on the BSCarouselControl. You can replicate this on any of your sample carousels by subscribing as so:
```csharp
<BSCarouselControl CarouselDirection="CarouselDirection.Previous" ActiveIndexChanged="@indexChanged" />
```

This leads to errors in both server and client side cases. Here is a shot of the server side error:
![image](https://user-images.githubusercontent.com/28515960/110672985-3e00fc80-819e-11eb-90ce-f772088e0351.png)

 Several things happened in this case:
1. Clicking on the BSCarouselControl element fires the slide transition code and then immediately fires the ActiveIndexChanged event.
2. The parent, seeing that an event has happened, calls SateHasChagned() and the BSCarousel componet re-renderes.
3. The BSCarousel component would automatically flush the list of Items due to the NumberOfItems parameter being re-set from the parent: 
```csharp
 [Parameter]
  public int NumberOfItems
  {
      get => _numberOfItems;
      set
      {
          if (_lastNumberItems != _numberOfItems)
          {
              CarouselItems.Clear();
          }
          _numberOfItems = value;
      }
  }
```
4. The animation would continue it's task and end up hitting one of the lines that assumed there were still Carousel items
```csharp
new Task(async () =>
  {
      AnimationRunning = true;
      await CarouselItems[ActiveIndex].Clean().ConfigureAwait(false);
      CarouselItems[ActiveIndex].Next = true;
      await CarouselItems[ActiveIndex].StateChanged().ConfigureAwait(false);
      await Task.Delay(300).ConfigureAwait(false);  // Gives animation time to shift and be ready to slide.
      CarouselItems[ActiveIndex].Left = true;
      CarouselItems[oldindex].Left = true;
      await CarouselItems[ActiveIndex].StateChanged().ConfigureAwait(false); // makes sure there is no gap
      await InvokeAsync(StateHasChanged).ConfigureAwait(false);
  }).Start();
```
5. Since the CarouselItems list has been cleared, the component would throw an exception.

I've re-written the BSCarousel initialization to avoid clearing the existing CarouselItems so that if something out of thread tried to access the list it would still have children to index.
```csharp
[Parameter] public int NumberOfItems { get; set; }
....
protected override void OnParametersSet()
{

    if (CarouselItems == null)
    {
        CarouselItems = new List<BSCarouselItem>();
    }

    if (CarouselIndicatorItems == null)
    {
        CarouselIndicatorItems = new List<BSCarouselIndicatorItem>();
    }

......
}
```

While I was in there, I have also re-written the animation system to use the BSCarousel as the main "driver" of changes. Instead of the child components directly modifying the ActiveIndex, they instead call helper functions in BSCarousel.

Before:
From BSCarouselControl.Razor.CS:
```csharp
protected async Task OnClick()
{
    if (Parent.AnimationRunning) return;
    if (CarouselDirection == CarouselDirection.Previous)
    {
        Parent.Direction = 1;
        Parent.ResetTimer();
        Parent.ActiveIndex = Parent.ActiveIndex == 0 ? NumberOfItems - 1 : Parent.ActiveIndex - 1;
    }
    else
    {
        Parent.Direction = 0;
        Parent.ResetTimer();
        Parent.ActiveIndex = Parent.ActiveIndex == NumberOfItems - 1 ? 0 : Parent.ActiveIndex + 1;
    }
    await ActiveIndexChanged.InvokeAsync(Parent.ActiveIndex).ConfigureAwait(false);
}
```

After:
```csharp

From BSCarouseLControl.Razor.CS:
 protected async Task OnClick()
  {
      if (Parent.AnimationRunning) return;
      if (CarouselDirection == CarouselDirection.Previous)
      {
          await Parent.GoToPrevItem().ConfigureAwait(true);
      }
      else
      {
          await Parent.GoToNextItem().ConfigureAwait(true);
      }
      await ActiveIndexChanged.InvokeAsync(Parent.ActiveIndex).ConfigureAwait(true);
  }

From BSCarouselControl
public async Task GoToNextItem()
{
    if (AnimationRunning) return;
    ResetTimer();
    ActiveIndex = ActiveIndex == NumberOfItems - 1 ? 0 : ActiveIndex + 1;
    await DoAnimations().ConfigureAwait(true);
}

public async Task GoToPrevItem()
{
    if (AnimationRunning) return;
    ResetTimer();
    ActiveIndex = ActiveIndex == 0 ? NumberOfItems - 1 : ActiveIndex - 1;
    await DoAnimations().ConfigureAwait(true);
}
```

Making BSCarousel the main driver means we can have everything happening in the same thread (except the Timer, no luck there). This means DoAnimations does not need to span the complex tasks as it was before. I don't necessarily believe this NEEDS to happen. The previous change means you won't have the out-of-thread issues but personally I think it is way cleaner and easier to debug. Happy to take this part out if you don't like it.  New DoAnimations:
 
```csharp
private async Task DoAnimations()
{
    if (CarouselItems.Count == 0) return;

    if (_timerEnabled)
    {
        Timer.Stop();
        Timer.Interval = CarouselItems[ActiveIndex].Interval;
    }

    AnimationRunning = true;
    CarouselItems[ActiveIndex].Clean();

    Direction = GetDirection();

    //Add new item to DOM on appropriate side
    CarouselItems[ActiveIndex].Next = Direction == 0;
    CarouselItems[ActiveIndex].Prev = Direction == 1;
    this.StateHasChanged();
    await Task.Delay(300).ConfigureAwait(true); //Ensure new item is rendered on DOM before continuing

    //Trigger Animation
    CarouselItems[ActiveIndex].Left = Direction == 0;
    CarouselItems[_prevIndex].Left = Direction == 0;

    CarouselItems[ActiveIndex].Right = Direction == 1;
    CarouselItems[_prevIndex].Right = Direction == 1;
    this.StateHasChanged();
        
}
```

If you notice, I no longer need all the various components to specify the direction, we can determine the direction by comparing the new index against the old index:
```csharp
private int _activeIndex { get; set; }
private int _prevIndex { get; set; }
public int ActiveIndex
{
    get => _activeIndex;
    set {
        _prevIndex = _activeIndex;
        _activeIndex = value;
    }
}
...
private int GetDirection()
{
  if (_prevIndex == 0)
  {
      if (ActiveIndex == NumberOfItems - 1)
      {
          return 1;
      } else
      {
          return 0;
      }
  }

  if (_prevIndex == NumberOfItems - 1)
  {
      if (ActiveIndex == 0)
      {
          return 0;
      } else
      {
          return 1;
      }
  }

  if (ActiveIndex > _prevIndex)
  {
      return 0;
  } else
  {
      return 1;
  }
}
```

Centralizing all the code means we can do some cool stuff where clicking on the BSCarouselIndicatorItem can actually transition directly to the right slide (just like in bootstrap).
```csharp
From BSCarouselIndicatorItem.Razor.CS:
protected async Task OnClick()
{
    await Parent.GoToSpecificItem(Index).ConfigureAwait(true);
    await ActiveIndexChangedEvent.InvokeAsync(Index).ConfigureAwait(true);
}

From BSCarousel.Razor.CS:
public async Task GoToSpecificItem(int index)
{
    if (AnimationRunning) return;
    ResetTimer();
    ActiveIndex = index;
    await DoAnimations().ConfigureAwait(true);
}

```

Also, having all the logic in BSCarousel means we can subscribe to index changes directly on BSCarousel instead of having to do it on the Indicator/Controls in the first place:
```csharp

From BSCarousel.Razor.CS:
[Parameter] public EventCallback<int> ActiveIndexChangedEvent { get; set; }
...
public async Task AnimationEnd(BSCarouselItem sender)
{
    if (sender == CarouselItems[ActiveIndex])
    {
        AnimationRunning = false;

        CarouselItems[_prevIndex].Clean();
        CarouselItems[ActiveIndex].Clean();
        CarouselItems[ActiveIndex].Active = true;
        this.StateHasChanged();

        if (_timerEnabled)
            Timer.Start();

        await ActiveIndexChangedEvent.InvokeAsync(ActiveIndex).ConfigureAwait(false);
    }
}

Updated carousels1 example:
<BSCarousel NumberOfItems="@items.Count" ActiveIndexChangedEvent="@indexChanged">
    ...
</BSCarousel>
```

Also while in there, I have removed some methods that were not referenced and consolidated the NumberOfItems from issue #379. Carousel examples are updated to match the changes.

Overall this should be a seamless upgrade for carousels. The one gotcha will be the NumberOfItems change from issue #379 since, after updating, the lower level components will not recognize the NumberOfItems parameter.

Lots of changes here, I'm sorry this isn't smaller PRs. Happy to refactor individual features if you need them. 