### PR TITLE
Allow modal to not have a close button

### DIFF
--- a/src/BlazorStrap-Docs/wwwroot/Static/Components/Modal.md
+++ b/src/BlazorStrap-Docs/wwwroot/Static/Components/Modal.md
@@ -12,7 +12,7 @@ See [shared](layout/shared) for additional parameters
 | IsCentered       | bool           | true/false     | `.modal-dialog-centered`          |
 | IsFullScreen     | bool           | true/false     | `.modal-fullscreen`               |
 | IsScrollable     | bool           | true/false     | `.modal-dialog-scrollable`        |
-| IsCloseable      | bool           | true/false     | Includes `.btn-close`             |
+| HasCloseButton   | bool           | true/false     | Includes `.btn-close`             |
 | ShowBackdrop     | bool           | true/false     |                                   |
 | ButtonClass      | string         | string         | custom class for the close button |
 | ContentClass     | string         | string         | custom class for `modal-body`     |

--- a/src/BlazorStrap-Docs/wwwroot/Static/Components/Modal.md
+++ b/src/BlazorStrap-Docs/wwwroot/Static/Components/Modal.md
@@ -12,6 +12,7 @@ See [shared](layout/shared) for additional parameters
 | IsCentered       | bool           | true/false     | `.modal-dialog-centered`          |
 | IsFullScreen     | bool           | true/false     | `.modal-fullscreen`               |
 | IsScrollable     | bool           | true/false     | `.modal-dialog-scrollable`        |
+| IsCloseable      | bool           | true/false     | Includes `.btn-close`             |
 | ShowBackdrop     | bool           | true/false     |                                   |
 | ButtonClass      | string         | string         | custom class for the close button |
 | ContentClass     | string         | string         | custom class for `modal-body`     |

--- a/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor
@@ -16,7 +16,10 @@
                 {
                     <div class="@HeaderClassBuilder">
                         @Header
-                        <button type="button" class="ms-auto btn-close @ButtonClass" data-bs-dismiss="modal" aria-label="Close" @onclick="EventUtil.AsNonRenderingEventHandler(ClickEvent)"></button>
+                        @if (IsCloseable)
+                        {
+                            <button type="button" class="ms-auto btn-close @ButtonClass" data-bs-dismiss="modal" aria-label="Close" @onclick="EventUtil.AsNonRenderingEventHandler(ClickEvent)"></button>
+                        }
                     </div>
                 }
                 <div class="@BodyClassBuilder">

--- a/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor
@@ -16,7 +16,7 @@
                 {
                     <div class="@HeaderClassBuilder">
                         @Header
-                        @if (IsCloseable)
+                        @if (HasCloseButton)
                         {
                             <button type="button" class="ms-auto btn-close @ButtonClass" data-bs-dismiss="modal" aria-label="Close" @onclick="EventUtil.AsNonRenderingEventHandler(ClickEvent)"></button>
                         }

--- a/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor.cs
@@ -26,7 +26,7 @@ namespace BlazorStrap
         [Parameter] public bool IsCentered { get; set; }
         [Parameter] public bool IsFullScreen { get; set; }
         [Parameter] public bool IsScrollable { get; set; }
-        [Parameter] public bool IsCloseable { get; set; } = true;
+        [Parameter] public bool HasCloseButton { get; set; } = true;
         [Parameter] public bool IsStaticBackdrop { get; set; }
         [Parameter] public bool ShowBackdrop { get; set; } = true;
         [Parameter] public Size Size { get; set; } = Size.None;

--- a/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor.cs
@@ -26,6 +26,7 @@ namespace BlazorStrap
         [Parameter] public bool IsCentered { get; set; }
         [Parameter] public bool IsFullScreen { get; set; }
         [Parameter] public bool IsScrollable { get; set; }
+        [Parameter] public bool IsCloseable { get; set; } = true;
         [Parameter] public bool IsStaticBackdrop { get; set; }
         [Parameter] public bool ShowBackdrop { get; set; } = true;
         [Parameter] public Size Size { get; set; } = Size.None;


### PR DESCRIPTION
This makes the close button in the modal optional, for cases where you just don't want to have one, or want to do something weirder to it than just adding a class.

(On a side note, shouldn't this be using `BSCloseButton`?)