### PR TITLE
Fix up progress bars

### DIFF
--- a/src/BlazorStrap-Docs/Samples/Components/Progress/Progress1.razor
+++ b/src/BlazorStrap-Docs/Samples/Components/Progress/Progress1.razor
@@ -1,6 +1,6 @@
 ﻿<BSProgress>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Primary" Value="15"></BSProgressBar>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Danger" Value="20"></BSProgressBar>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Success" Value="10"></BSProgressBar>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Warning" Value="5"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Primary" Value="15"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Danger" Value="20"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Success" Value="10"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Warning" Value="5"></BSProgressBar>
 </BSProgress>

--- a/src/BlazorStrap-Docs/Samples/Components/Progress/Progress2.razor
+++ b/src/BlazorStrap-Docs/Samples/Components/Progress/Progress2.razor
@@ -1,0 +1,53 @@
+﻿@implements IDisposable
+
+<BSProgress>
+    <BSProgressBar Color="BSColor.Primary" Value="@Value">@(Math.Round(Value))%</BSProgressBar>
+</BSProgress>
+<BSProgress>
+    <BSProgressBar Color="BSColor.Danger" Value="@Value1"></BSProgressBar>
+    <BSProgressBar Color="BSColor.Warning" Value="@Value2"></BSProgressBar>
+    <BSProgressBar Color="BSColor.Success" Value="@Value3"></BSProgressBar>
+</BSProgress>
+<BSButton Color="BSColor.Primary" OnClick="Toggle" MarginTop="Margins.Medium">Start/Stop</BSButton>
+
+@code {
+    private double Value = 35;
+    private double Value1 = 35;
+    private double Value2 = 0;
+    private double Value3 = 0;
+    private bool running = false;
+    private Timer timer = default!;
+
+    protected override void OnInitialized()
+    {
+        timer = new Timer(Tick);
+        base.OnInitialized();
+    }
+
+    public void Dispose()
+    {
+        timer.Dispose();
+    }
+
+    private void Toggle()
+    {
+        running = !running;
+        if (running)
+        {
+            timer.Change(0, 500);
+        }
+        else
+        {
+            timer.Change(Timeout.Infinite, Timeout.Infinite);
+        }
+    }
+
+    private void Tick(object? _)
+    {
+        Value = (Value + 5) % 105;
+        Value1 = Math.Clamp(Value, 0, 50);
+        Value2 = Math.Clamp(Value - 50, 0, 30);
+        Value3 = Math.Clamp(Value - 80, 0, 20);
+        InvokeAsync(StateHasChanged);
+    }
+}

--- a/src/BlazorStrap-Docs/wwwroot/Samples/Components/Progress/Progress1.md
+++ b/src/BlazorStrap-Docs/wwwroot/Samples/Components/Progress/Progress1.md
@@ -1,6 +1,6 @@
 ﻿<BSProgress>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Primary" Value="15"></BSProgressBar>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Danger" Value="20"></BSProgressBar>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Success" Value="10"></BSProgressBar>
-    <BSProgressBar IsStriped="true" Max="25" Color="BSColor.Warning" Value="5"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Primary" Value="15"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Danger" Value="20"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Success" Value="10"></BSProgressBar>
+    <BSProgressBar IsStriped="true" Color="BSColor.Warning" Value="5"></BSProgressBar>
 </BSProgress>

--- a/src/BlazorStrap-Docs/wwwroot/Samples/Components/Progress/Progress2.md
+++ b/src/BlazorStrap-Docs/wwwroot/Samples/Components/Progress/Progress2.md
@@ -1,0 +1,53 @@
+﻿@implements IDisposable
+
+<BSProgress>
+    <BSProgressBar Color="BSColor.Primary" Value="@Value">@(Math.Round(Value))%</BSProgressBar>
+</BSProgress>
+<BSProgress>
+    <BSProgressBar Color="BSColor.Danger" Value="@Value1"></BSProgressBar>
+    <BSProgressBar Color="BSColor.Warning" Value="@Value2"></BSProgressBar>
+    <BSProgressBar Color="BSColor.Success" Value="@Value3"></BSProgressBar>
+</BSProgress>
+<BSButton Color="BSColor.Primary" OnClick="Toggle" MarginTop="Margins.Medium">Start/Stop</BSButton>
+
+@code {
+    private double Value = 35;
+    private double Value1 = 35;
+    private double Value2 = 0;
+    private double Value3 = 0;
+    private bool running = false;
+    private Timer timer = default!;
+
+    protected override void OnInitialized()
+    {
+        timer = new Timer(Tick);
+        base.OnInitialized();
+    }
+
+    public void Dispose()
+    {
+        timer.Dispose();
+    }
+
+    private void Toggle()
+    {
+        running = !running;
+        if (running)
+        {
+            timer.Change(0, 500);
+        }
+        else
+        {
+            timer.Change(Timeout.Infinite, Timeout.Infinite);
+        }
+    }
+
+    private void Tick(object? _)
+    {
+        Value = (Value + 5) % 105;
+        Value1 = Math.Clamp(Value, 0, 50);
+        Value2 = Math.Clamp(Value - 50, 0, 30);
+        Value3 = Math.Clamp(Value - 80, 0, 20);
+        InvokeAsync(StateHasChanged);
+    }
+}

--- a/src/BlazorStrap-Docs/wwwroot/Static/Components/Progress.md
+++ b/src/BlazorStrap-Docs/wwwroot/Static/Components/Progress.md
@@ -3,15 +3,26 @@
 #### Component \<BSProgress\>
 See [shared](layout/shared) for additional parameters    
 
-#### Component \<BSListGroupItem\>
+Include one or more `BSProgressBar` inside.
+
+When using multiple bars, their total percentage should not exceed 100%.
+
+#### Component \<BSProgressBar\>
 :::
 
-| Parameter | Type | Valid      | Remarks/Output        | 
-|-----------|------|------------|-----------------------|
-| Color     | Enum | BSColor    | `.bg-[]`              | {.table-striped .p-2}
-| IsActive  | bool | true/false | `.active`             |
+| Parameter  | Type   | Valid      | Remarks/Output           | 
+|------------|--------|------------|--------------------------|
+| Color      | Enum   | BSColor    | `.bg-[]`                 | {.table-striped .p-2}
+| IsStriped  | bool   | true/false | `.progress-bar-striped`  |
+| IsAnimated | bool   | true/false | `.progress-bar-animated` |
+| Value      | double | min..max   | current value            |
+| Min        | double |            | min value (default 0)    |
+| Max        | double |            | max value (default 100)  |
 
 :::
 
 ### Example
 {{sample=Components/Progress/Progress1}}
+
+### Dynamic
+{{sample=Components/Progress/Progress2}}

--- a/src/BlazorStrap/Components/BootstrapComponents/BSProgressBar.razor
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSProgressBar.razor
@@ -1,6 +1,6 @@
 ﻿@namespace BlazorStrap
 @inherits BlazorStrapBase
 
-<div class="@ClassBuilder" style="@(Style+Width)" role="progressbar" aria-valuenow="@Value" aria-valuemin="0" aria-valuemax="@Max" @attributes="@Attributes">
+<div class="@ClassBuilder" style="@(Style+Width)" role="progressbar" aria-valuenow="@Value" aria-valuemin="@Min" aria-valuemax="@Max" @attributes="@Attributes">
     @ChildContent
 </div>

--- a/src/BlazorStrap/Components/BootstrapComponents/BSProgressBar.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSProgressBar.razor.cs
@@ -9,6 +9,7 @@ namespace BlazorStrap
         [Parameter] public BSColor Color { get; set; } = BSColor.Default;
         [Parameter] public bool IsAnimated { get; set; }
         [Parameter] public bool IsStriped { get; set; }
+        [Parameter] public double Min { get; set; } = 0;
         [Parameter] public double Max { get; set; } = 100;
         
         [Parameter] public double Value
@@ -39,15 +40,16 @@ namespace BlazorStrap
                 Parent.AddChild(this);
             }
         }
+        protected override void OnParametersSet()
+        {
+            NotifyChildren();
+            base.OnParametersSet();
+        }
         private void NotifyChildren()
         {
-            var percent = (_value / Max * 100);
-            if (Parent != null)
-            {
-                percent = (_value / Max * 100) / (Parent.Children.Count);
-            }
+            var percent = (_value - Min) / (Max - Min) * 100;
 
-            Width = $"width:{Math.Round(percent).ToString(CultureInfo.InvariantCulture)}%;" ;
+            Width = $"width:{percent.ToString(CultureInfo.InvariantCulture)}%;" ;
         }
         protected virtual void Dispose(bool disposing) { }
         public void Dispose()


### PR DESCRIPTION
Fixes a bunch of issues with the `BSProgress`/`BSProgressBar`:
* Adds a `Min` parameter.
* Fixes the docs to actually list the parameters.
* Adds an example showing dynamic updating of the progress bar value.
* Fixes bugs so that the example actually works.
* Fixes the width calculation for multiple progress bars (breaking change, see below for justification).
* Removes rounding of the width percentage (all browsers should cope with decimal widths just fine, and rounding may introduce errors).

Previously, updating the `Value` parameter from the containing component did update the `aria-valuenow` to match, but didn't update the actual rendering of the progress bar.  This was because the `Width` property was only ever updated when progress bars are added/removed, not when parameters were changed.

This also gets rid of the width adjustment for multiple bars (this is the breaking change).  Previously, when multiple bars were present it treated "100%" of one bar to be e.g. 33% of the total width (when three bars were present).  This is not at all how the native Bootstrap progress bars behave, and it doesn't allow progress bars of uneven fill widths -- e.g. if you imagine them to be different steps of a pizza order (processing, making, cooking, waiting, delivering, etc) then these may fill to 100% in the end but not evenly.  And this seems safe to change because due to the above nobody could have been using progress bars before anyway. 😆 

(If you try out the new example with the old implementation, you can see that the percentage value updates but the progress bar itself doesn't move.)