### PR TITLE
Update Shown/Show/Hide

### DIFF
--- a/src/BlazorStrap/Components/BootstrapComponents/BSAccordionItem.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSAccordionItem.razor.cs
@@ -49,10 +49,12 @@ namespace BlazorStrap
         private ElementReference MyRef { get; set; }
 
         // Can be access by @ref
-        private bool Shown { get; set; }
+        public bool Shown { get; private set; }
 
         public override async Task ShowAsync()
         {
+            if (Shown) return;
+
             await BlazorStrap.Interop.RemoveClassAsync(ButtonRef, "collapsed");
             await BlazorStrap.Interop.AddAttributeAsync(ButtonRef, "aria-expanded", (!Shown).ToString().ToLower());
             if (OnShow.HasDelegate)
@@ -69,6 +71,8 @@ namespace BlazorStrap
         }
         public override async Task HideAsync()
         {
+            if (!Shown) return;
+
             await BlazorStrap.Interop.AddClassAsync(ButtonRef, "collapsed");
             await BlazorStrap.Interop.AddAttributeAsync(ButtonRef, "aria-expanded", (!Shown).ToString().ToLower());
             if (OnHide.HasDelegate)

--- a/src/BlazorStrap/Components/BootstrapComponents/BSCollapse.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSCollapse.razor.cs
@@ -48,6 +48,8 @@ namespace BlazorStrap
 
         public override async Task ShowAsync()
         {
+            if (Shown) return;
+
             if (OnShow.HasDelegate)
                 await OnShow.InvokeAsync(this);
 
@@ -61,6 +63,8 @@ namespace BlazorStrap
         }
         public override async Task HideAsync()
         {
+            if (!Shown) return;
+
             if (OnHide.HasDelegate)
                 await OnHide.InvokeAsync(this);
             if (_lock) return;

--- a/src/BlazorStrap/Components/BootstrapComponents/BSDropdown.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSDropdown.razor.cs
@@ -54,11 +54,13 @@ namespace BlazorStrap
         private ElementReference MyRef { get; set; }
         internal Action<bool, BSDropdownItem>? OnSetActive { get; set; }
         private BSPopover? PopoverRef { get; set; }
-        internal bool Shown { get; private set; }
+        public bool Shown { get; private set; }
 
         // ReSharper disable once MemberCanBePrivate.Global
         public async Task HideAsync()
         {
+            if (!Shown) return;
+
             Shown = false;
             await BlazorStrap.Interop.RemoveDocumentEventAsync(this, DataRefId, EventType.Click);
 
@@ -106,6 +108,8 @@ namespace BlazorStrap
         // ReSharper disable once MemberCanBePrivate.Global
         public async Task ShowAsync()
         {
+            if (Shown) return;
+
             Shown = true;
 
             if (!AllowOutsideClick)

--- a/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSModal.razor.cs
@@ -77,16 +77,18 @@ namespace BlazorStrap
 
         private ElementReference MyRef { get; set; }
 
-        private bool Shown
+        public bool Shown
         {
             get => _shown;
-            set => _shown = value;
+            private set => _shown = value;
         }
 
         private string Style { get; set; } = "display: none;";
 
         public override async Task HideAsync()
         {
+            if (!Shown) return;
+
             _called = true;
             _lock = true;
             Shown = false;
@@ -125,6 +127,8 @@ namespace BlazorStrap
 
         public override async Task ShowAsync()
         {
+            if (Shown) return;
+
             _called = true;
             _lock = true;
             Shown = true;

--- a/src/BlazorStrap/Components/BootstrapComponents/BSOffCanvas.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSOffCanvas.razor.cs
@@ -53,14 +53,16 @@ namespace BlazorStrap
             return !_lock;
         }
 
-        private bool Shown
+        public bool Shown
         {
             get => _shown;
-            set => _shown = value;
+            private set => _shown = value;
         }
 
         public override async Task ShowAsync()
         {
+            if (Shown) return;
+
             // Used to hide popovers
             BlazorStrap.ForwardToggle("", this);
             _lock = true;
@@ -90,6 +92,8 @@ namespace BlazorStrap
 
         public override async Task HideAsync()
         {
+            if (!Shown) return;
+
             // Used to hide popovers
             BlazorStrap.ForwardToggle("", this);
             _lock = true;

--- a/src/BlazorStrap/Components/BootstrapComponents/BSPopover.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSPopover.razor.cs
@@ -50,11 +50,13 @@ namespace BlazorStrap
             .Build().ToNullString();
 
         private ElementReference MyRef { get; set; }
-        private bool Shown { get; set; }
+        public bool Shown { get; private set; }
         private string Style { get; set; } = "display:none;";
 
         public override async Task HideAsync()
         {
+            if (!Shown) return;
+
             if (OnHide.HasDelegate)
                 await OnHide.InvokeAsync(this);
             _called = true;
@@ -68,6 +70,8 @@ namespace BlazorStrap
 
         public override async Task ShowAsync()
         {
+            if (Shown) return;
+
             if (Target == null)
             {
                 throw new NullReferenceException("Target cannot be null");

--- a/src/BlazorStrap/Components/BootstrapComponents/BSToast.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSToast.razor.cs
@@ -65,7 +65,7 @@ namespace BlazorStrap
             return false;
         }
 
-        private bool Shown { get; set; } = true;
+        public bool Shown { get; private set; } = true;
 
         public void Toggle()
         {

--- a/src/BlazorStrap/Components/BootstrapComponents/BSTooltip.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSTooltip.razor.cs
@@ -20,11 +20,13 @@ namespace BlazorStrap
         private bool HasRender { get; set; }
 
         private ElementReference MyRef { get; set; }
-        private bool Shown { get; set; }
+        public bool Shown { get; private set; }
         private string Style { get; set; } = "display:none";
 
         public override async Task HideAsync()
         {
+            if (!Shown) return;
+
             if (OnHide.HasDelegate)
                 await OnHide.InvokeAsync(this);
             Shown = false;
@@ -38,6 +40,8 @@ namespace BlazorStrap
 
         public override async Task ShowAsync()
         {
+            if (Shown) return;
+
             if (OnShow.HasDelegate)
                 await OnShow.InvokeAsync(this);
             Shown = true;

--- a/src/BlazorStrap/InternalComponents/Backdrop.razor.cs
+++ b/src/BlazorStrap/InternalComponents/Backdrop.razor.cs
@@ -12,7 +12,7 @@ public partial class Backdrop : ComponentBase
     [Inject] private IBlazorStrap BlazorStrapService { get; set; } = default!;
     // ReSharper disable once NullableWarningSuppressionIsUsed
     [Parameter] public bool ShowBackdrop { get; set; }
-    private bool Shown { get; set; }
+    public bool Shown { get; private set; }
     private BlazorStrapCore BlazorStrap => (BlazorStrapCore)BlazorStrapService;
     private string? BackdropClass => new CssBuilder("modal-backdrop")
         .AddClass("fade")


### PR DESCRIPTION
* Makes the `Shown` property readable, if you have a component ref (makes sense to be able to tell whether it's shown or not without having to keep external track yourself)
* Ignores `ShowAsync` if already shown
* Ignores `HideAsync` if already hidden

FWIW the specific bug I encountered was that calling `HideAsync` on an already-hidden `BSModal` causes the backdrop to appear (since internally that only has a toggle).  But it makes sense to fix up all of these usages to be safer.