### PR TITLE
Fix breadcrumb debug code

### DIFF
--- a/src/BlazorStrap/Components/BootstrapComponents/BSBreadcrumb.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSBreadcrumb.razor.cs
@@ -24,8 +24,8 @@ namespace BlazorStrap
             if (NavigationManager == null) return;
             NavigationManager.LocationChanged += OnLocationChanged;
             
-            Tree = GetPath(NavigationManager.Uri, BasePath, Labels, "https://localhost:7262/V5/" ?? "");
-            //Tree = GetPath(NavigationManager.Uri, BasePath, Labels, NavigationManager?.BaseUri ?? "");
+            //Tree = GetPath(NavigationManager.Uri, BasePath, Labels, "https://localhost:7262/V5/" ?? "");
+            Tree = GetPath(NavigationManager.Uri, BasePath, Labels, NavigationManager?.BaseUri ?? "");
         }
 
         private void OnLocationChanged(object? sender, LocationChangedEventArgs e)


### PR DESCRIPTION
This removes an obvious bit of debug code left behind in the breadcrumb component that means the `BasePath` handling cannot possibly work.

Having said this, I'm a bit confused at the logic of this and I don't see why it doesn't just use [`MakeRelativeUri`](https://docs.microsoft.com/en-us/dotnet/api/system.uri.makerelativeuri?view=net-6.0) on the `NavigationManager.BaseUri` (I also don't see why the `NavigationManager` doesn't just provide a relative URI by default anyway, but that's a different topic).