### PR TITLE
Fixes for BSFeedback

### DIFF
--- a/src/BlazorStrap/Components/Forms/BSFeedback.cs
+++ b/src/BlazorStrap/Components/Forms/BSFeedback.cs
@@ -19,7 +19,7 @@ namespace BlazorStrap
         [Parameter] public TValue? IsManual { get; set; }
 
         private string? ClassBuilder => new CssBuilder()
-            .AddClass("valid-tooltip", IsTooltip && !IsValid)
+            .AddClass("valid-tooltip", IsTooltip && IsValid)
             .AddClass("valid-feedback", !IsTooltip && IsValid)
             .AddClass("invalid-tooltip", IsTooltip && IsInvalid)
             .AddClass("invalid-feedback", !IsTooltip && IsInvalid)
@@ -53,6 +53,8 @@ namespace BlazorStrap
         [Parameter] public string? InvalidMessage { get; set; }
 
         protected internal FieldIdentifier FieldIdentifier { get; set; }
+
+        private string? _ActualInvalidMessage;
 
         protected override void OnParametersSet()
         {
@@ -89,6 +91,8 @@ namespace BlazorStrap
                 return;
             }
 
+            _ActualInvalidMessage = InvalidMessage;
+
             if (EditContext.IsModified(FieldIdentifier))
             {
                 if (EditContext.GetValidationMessages(FieldIdentifier).Any())
@@ -113,29 +117,30 @@ namespace BlazorStrap
         {
             if (EditContext != null)
             {
-                if (InvalidMessage == null)
+                if (_ActualInvalidMessage == null)
                 {
                     var first = true;
                     foreach (var message in EditContext.GetValidationMessages(FieldIdentifier))
                     {
                         if (first)
                         {
-                            InvalidMessage = message;
+                            _ActualInvalidMessage = message;
                             first = false;
                         }
                         else
                         {
-                            InvalidMessage += $"<br/>{message}";
+                            _ActualInvalidMessage += $"<br/>{message}";
                         }
                     }
                 }
             }
 
-            if (!IsInvalid && !IsInvalid) return;
+            var content = IsInvalid ? _ActualInvalidMessage : IsValid ? ValidMessage : null;
+            if (content == null) return;
             builder.OpenElement(0, "div");
             builder.AddAttribute(1, "class", ClassBuilder);
             builder.AddMultipleAttributes(2, Attributes);
-            builder.AddContent(3, InvalidMessage);
+            builder.AddContent(3, content);
             builder.CloseElement();
         }
         public void Dispose()

--- a/src/BlazorStrap/Components/Forms/BSFeedback.cs
+++ b/src/BlazorStrap/Components/Forms/BSFeedback.cs
@@ -67,6 +67,7 @@ namespace BlazorStrap
                     EditContext = CascadedEditContext;
                     if (For != null) FieldIdentifier = FieldIdentifier.Create(For);
                     EditContext.OnValidationStateChanged += OnValidationStateChanged;
+                    DoValidation();
                 }
             }
             else if (CascadedEditContext != EditContext)


### PR DESCRIPTION
* When `IsTooltip`, the `valid-tooltip` style was being applied when invalid and not when valid.
* If a `ValidMessage` was set, it was completely ignored instead of being displayed when valid.
* If no `InvalidMessage` was set, it was correctly obtaining a message from the validation context, but then re-using the same message on any subsequent invalid state instead of updating to the new validation error.
    * For example, a field is given an invalid value and it displays error A that correctly corresponds to that.  Later, the field is given a different invalid value and it still displays error A despite the validation context now reporting error B.
    * As a general rule, it is a bad idea for components to ever write to their `[Parameter]` properties.  This is called out in the official Blazor docs.  (Even bound properties shouldn't do so -- they should just raise the changed event, which then propagates the new value back in from the parent.)
* Now removes the element when there is nothing to display (e.g. valid but no `ValidMessage` set).
* Ensures state is consistent when first created (just in case the form is already in a modified state).