### PR TITLE
Don't submit when clicking buttons

### DIFF
--- a/src/BlazorStrap/Components/BootstrapComponents/BSDropdownItem.razor
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSDropdownItem.razor
@@ -19,7 +19,7 @@
     {
         @if (IsButton)
         {
-            <button class="@ClassBuilder" @attributes="Attributes" @onclick="ClickEvent" @onclick:preventDefault="PreventDefault">@ChildContent</button>
+            <button type="button" class="@ClassBuilder" @attributes="Attributes" @onclick="ClickEvent" @onclick:preventDefault="PreventDefault">@ChildContent</button>
         }
         else if (IsText)
         {
@@ -74,7 +74,7 @@
         <li>
             @if (IsButton)
             {
-                <button class="@ClassBuilder" @attributes="Attributes" @onclick="ClickEvent" @onclick:preventDefault="PreventDefault">@ChildContent</button>
+                <button type="button" class="@ClassBuilder" @attributes="Attributes" @onclick="ClickEvent" @onclick:preventDefault="PreventDefault">@ChildContent</button>
             }
             else if (IsText)
             {

--- a/src/BlazorStrap/Components/BootstrapComponents/BSListGroupItem.razor
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSListGroupItem.razor
@@ -7,7 +7,7 @@
 }
 else if (IsButton)
 {
-    <button class="@ClassBuilder" @onclick="ClickEvent" @onclick:preventDefault="PreventDefault">@ChildContent</button>
+    <button type="button" class="@ClassBuilder" @onclick="ClickEvent" @onclick:preventDefault="PreventDefault">@ChildContent</button>
 }
 else
 {

--- a/src/BlazorStrap/Components/BootstrapComponents/BSToggle.razor
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSToggle.razor
@@ -9,7 +9,7 @@
 }
 else
 {
-    <button class="@ClassBuilder" aria-expanded="@Show().ToString().ToLower()" @attributes="Attributes" @onclick="ClickEvent" data-blazorstrap="@DataId" data-blazorstrap-target="@Target" data-bs-toggle="@Element" @ref="MyRef">
+    <button type="button" class="@ClassBuilder" aria-expanded="@Show().ToString().ToLower()" @attributes="Attributes" @onclick="ClickEvent" data-blazorstrap="@DataId" data-blazorstrap-target="@Target" data-bs-toggle="@Element" @ref="MyRef">
         @ChildContent
     </button>
 }


### PR DESCRIPTION
This adds some missing `type="button"` on `<button>` elements, because the HTML standard decided in its infinite wisdom that clicking buttons inside forms should submit them by default unless you explicitly tell them not to.

If you _really_ want these to be a submit button, you can (in 2/3 cases) re-enable it by overriding the type attribute.  But it's very unlikely that you do.