### PR TITLE
Ignore duplicate calls to show/hide

### DIFF
--- a/src/BlazorStrap/Components/BootstrapComponents/BSDropdown.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSDropdown.razor.cs
@@ -153,7 +153,6 @@ namespace BlazorStrap
         // ReSharper disable once MemberCanBePrivate.Global
         public Task HideAsync()
         {
-            if (!Shown) return Task.CompletedTask;
             _callback = async () =>
             {
                 await HideActionsAsync();
@@ -163,6 +162,7 @@ namespace BlazorStrap
 
         private async Task HideActionsAsync()
         {
+            if (!Shown) return;
             Shown = false;
             await BlazorStrap.Interop.RemoveDocumentEventAsync(this, DataRefId, EventType.Click);
 
@@ -214,7 +214,6 @@ namespace BlazorStrap
         // ReSharper disable once MemberCanBePrivate.Global
         public Task ShowAsync()
         {
-            if (Shown) return Task.CompletedTask;
             _callback = async () =>
             {
                 await ShowActionsAsync();
@@ -224,6 +223,7 @@ namespace BlazorStrap
 
         private async Task ShowActionsAsync()
         {
+            if (Shown) return;
             Shown = true;
 
             if (!AllowOutsideClick)

--- a/src/BlazorStrap/Components/BootstrapComponents/BSPopover.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSPopover.razor.cs
@@ -118,7 +118,6 @@ namespace BlazorStrap
         /// <inheritdoc/>
         public override Task HideAsync()
         {
-            if (!Shown) return Task.CompletedTask;
             _callback = async () =>
             {
                 await HideActionsAsync();
@@ -128,6 +127,7 @@ namespace BlazorStrap
 
         private async Task HideActionsAsync()
         {
+            if (!Shown) return;
             if (OnHide.HasDelegate)
                 await OnHide.InvokeAsync(this);
             _called = true;
@@ -142,7 +142,6 @@ namespace BlazorStrap
         /// <inheritdoc/>
         public override Task ShowAsync()
         {
-            if (Shown) return Task.CompletedTask;
             _callback = async () =>
             {
                 await ShowActionsAsync();
@@ -157,6 +156,7 @@ namespace BlazorStrap
                 throw new NullReferenceException("Target cannot be null");
             }
 
+            if (Shown) return;
             _called = true;
             if (OnShow.HasDelegate)
                 await OnShow.InvokeAsync(this);


### PR DESCRIPTION
This successfully works around the problem mentioned in #528, but perhaps does not solve their underlying causes.

For whatever reason it looks like a single click on a BSToggle resulted in two calls to ShowActionsAsync (and the same on hiding), and that consequently two calls to `AddDocumentEventAsync` were made without unregistering in between, which appeared to get the event registration "stuck on" (even though more than two calls to remove it also happened, it was not actually removed).

This change doesn't prevent the multiple calls from happening, but it does ignore the second one.