### PR TITLE
Tooltips wouldn't fully hide

### DIFF
--- a/src/BlazorStrap/Components/BootstrapComponents/BSTooltip.razor.cs
+++ b/src/BlazorStrap/Components/BootstrapComponents/BSTooltip.razor.cs
@@ -65,7 +65,7 @@ namespace BlazorStrap
             if (OnHide.HasDelegate)
                 await OnHide.InvokeAsync(this);
             Shown = false;
-            await BlazorStrap.Interop.SetStyleAsync(MyRef, "display", "name");
+            await BlazorStrap.Interop.SetStyleAsync(MyRef, "display", "none");
             await BlazorStrap.Interop.RemoveClassAsync(MyRef, "show");
             await BlazorStrap.Interop.RemovePopoverAsync(MyRef, DataId);
 


### PR DESCRIPTION
A typo in `BSTooltip` was making it so that after showing and hiding a tooltip, it was not visible but was still intercepting mouse events.

In my case that was making it so that in a grid of icons with tooltips, fewer and fewer would actually work since the `mouseenter` event wasn't reaching the icon; it was being intercepted by the tooltip instead.

(I'm not sure why anyone would put interactive elements into a tooltip anyway, so they shouldn't need pointer events in the first place, but apparently some people do.)

Caveat: I can't really tell in my test environment since I have animations disabled, but this does seem like perhaps this might make the tooltips vanish immediately instead of fading out... are they supposed to fade out?