### PR TITLE
Parse any type

### DIFF
--- a/src/BlazorStrap/Utilities/TryParseString.cs
+++ b/src/BlazorStrap/Utilities/TryParseString.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.ComponentModel;
+using Microsoft.AspNetCore.Components;
 using System.Globalization;
 using System.Reflection;
 using static System.Nullable;
@@ -282,6 +283,15 @@ namespace BlazorStrap.Utilities
                     return false;
                 }
             }
+
+            if (BindConverter.TryConvertTo<T>(value, CultureInfo.CurrentCulture, out var parsedValue))
+            {
+                result = parsedValue;
+                validationErrorMessage = null;
+                return true;
+            }
+
+            validationErrorMessage = string.Format(CultureInfo.InvariantCulture, "The {0} is not valid.", type.Name);
             return false;
         }
 


### PR DESCRIPTION
This extends `BSInput`'s parsing further to allow it to parse (almost) any type.

(The previous implementation just reported an empty string error when it encountered an unsupported type, which included `uint`.)

In actual fact, the generic implementation supports all of the other types that are being manually parsed above, so it's likely that they all could be removed and just let that do all the work.  I haven't done that because I haven't checked if there's some quirk of the current parsing that's somehow different from the generic parsing.