### PR TITLE
Exception defence

### DIFF
--- a/src/BlazorStrap/Utilities/TryParseString.cs
+++ b/src/BlazorStrap/Utilities/TryParseString.cs
@@ -284,11 +284,19 @@ namespace BlazorStrap.Utilities
                 }
             }
 
-            if (BindConverter.TryConvertTo<T>(value, CultureInfo.CurrentCulture, out var parsedValue))
+            try
             {
-                result = parsedValue;
-                validationErrorMessage = null;
-                return true;
+                if (BindConverter.TryConvertTo<T>(value, CultureInfo.CurrentCulture, out var parsedValue))
+                {
+                    result = parsedValue;
+                    validationErrorMessage = null;
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                validationErrorMessage = ex.Message;
+                return false;
             }
 
             validationErrorMessage = string.Format(CultureInfo.InvariantCulture, "The {0} is not valid.", type.Name);


### PR DESCRIPTION
[I think it's a framework bug](https://github.com/dotnet/aspnetcore/issues/42435) but it turns out that `BindConverter.TryConvertTo` can throw exceptions for certain kinds of parsing failures.  So defend against that.