### PR TITLE
Add property FilterSize to BSDataTableHead

### DIFF
--- a/src/BlazorStrap-Docs/wwwroot/Static/V4/Content/Tables.md
+++ b/src/BlazorStrap-Docs/wwwroot/Static/V4/Content/Tables.md
@@ -77,11 +77,12 @@ See [shared](layout/shared) for additional parameters
 See [shared](layout/shared) for additional parameters    
 :::
 
-| Parameter    | Type   | Valid       | Remarks/Output | 
-|--------------|--------|-------------|----------------|
-| Column       | string | column name |                | {.table-striped .p-2} 
-| Sortable     | bool   | bool        |                |
-| ColumnFilter | bool   | bool        |                |
+| Parameter    | Type   | Valid       | Remarks/Output                      | 
+|--------------|--------|-------------|-------------------------------------|
+| Column       | string | column name |                                     | {.table-striped .p-2} 
+| Sortable     | bool   | bool        |                                     |
+| ColumnFilter | bool   | bool        |                                     |
+| FilterSize   | Size   | Size        | The size of the column filter input |
 
 #### Component \<BSDataTableRow\> (Version  >= 5.0.105-Preview1)
 See [shared](layout/shared) for additional parameters    

--- a/src/BlazorStrap-Docs/wwwroot/Static/V5/Content/Tables.md
+++ b/src/BlazorStrap-Docs/wwwroot/Static/V5/Content/Tables.md
@@ -77,11 +77,12 @@ See [shared](layout/shared) for additional parameters
 See [shared](layout/shared) for additional parameters    
 :::
 
-| Parameter    | Type   | Valid       | Remarks/Output | 
-|--------------|--------|-------------|----------------|
-| Column       | string | column name |                | {.table-striped .p-2} 
-| Sortable     | bool   | bool        |                |
-| ColumnFilter | bool   | bool        |                |
+| Parameter    | Type   | Valid       | Remarks/Output                      | 
+|--------------|--------|-------------|-------------------------------------|
+| Column       | string | column name |                                     | {.table-striped .p-2} 
+| Sortable     | bool   | bool        |                                     |
+| ColumnFilter | bool   | bool        |                                     |
+| FilterSize   | Size   | Size        | The size of the column filter input |
 
 #### Component \<BSDataTableRow\> (Version  >= 5.0.105-Preview1)
 See [shared](layout/shared) for additional parameters    

--- a/src/BlazorStrap.V4/Components/Datatable/BSDataTableHead.razor
+++ b/src/BlazorStrap.V4/Components/Datatable/BSDataTableHead.razor
@@ -13,7 +13,7 @@
     }
     @if (ColumnFilter)
     {
-        <BSInput InputType="InputType.Text" Value="Filter" placeholder="Type to filter" UpdateOnInput="true" ValueChanged="(string e) => FilterChanged(e)" />
+        <BSInput InputSize="FilterSize" InputType="InputType.Text" Value="Filter" placeholder="Type to filter" UpdateOnInput="true" ValueChanged="(string e) => FilterChanged(e)" />
     }
 </th>
 

--- a/src/BlazorStrap.V4/Components/Datatable/BSDataTableHead.razor.cs
+++ b/src/BlazorStrap.V4/Components/Datatable/BSDataTableHead.razor.cs
@@ -1,11 +1,16 @@
 using BlazorComponentUtilities;
 using BlazorStrap.Extensions;
 using BlazorStrap.Shared.Components.Datatable;
+using Microsoft.AspNetCore.Components;
 
 namespace BlazorStrap.V4
 {
     public partial class BSDataTableHead<TValue> : BSDataTableHeadBase<TValue>
     {
+        /// <summary>
+        /// Size of the filter input.
+        /// </summary>
+        [Parameter] public Size FilterSize { get; set; }
         protected override string? SortClassBuilder => new CssBuilder()
                 .AddClass("sort-by", Desc == null)
                 .AddClass("sort", Desc == false)

--- a/src/BlazorStrap.V5/Components/Datatable/BSDataTableHead.razor
+++ b/src/BlazorStrap.V5/Components/Datatable/BSDataTableHead.razor
@@ -13,7 +13,7 @@
     }
     @if (ColumnFilter)
     {
-        <BSInput InputType="InputType.Text" Value="Filter" placeholder="Type to filter" UpdateOnInput="true" ValueChanged="(string e) => FilterChanged(e)" />
+        <BSInput InputSize="FilterSize" InputType="InputType.Text" Value="Filter" placeholder="Type to filter" UpdateOnInput="true" ValueChanged="(string e) => FilterChanged(e)" />
     }
 </th>
 

--- a/src/BlazorStrap.V5/Components/Datatable/BSDataTableHead.razor.cs
+++ b/src/BlazorStrap.V5/Components/Datatable/BSDataTableHead.razor.cs
@@ -1,11 +1,17 @@
 using BlazorComponentUtilities;
 using BlazorStrap.Extensions;
 using BlazorStrap.Shared.Components.Datatable;
+using Microsoft.AspNetCore.Components;
 
 namespace BlazorStrap.V5
 {
     public partial class BSDataTableHead<TValue> : BSDataTableHeadBase<TValue>
     {
+        /// <summary>
+        /// Size of the filter input.
+        /// </summary>
+        [Parameter] public Size FilterSize { get; set; }
+
         protected override string? SortClassBuilder => new CssBuilder()
                 .AddClass("sort-by", Desc == null)
                 .AddClass("sort", Desc == false)


### PR DESCRIPTION
There was no way to change the size of the column filter input for a `BSDataTableHead`. For a `BSTable` with `IsSmall="true"` the filter input box looked to big.

This PR adds a property `FilterSize` (of type Size) which sets the `InputSize` property of the filter text box.