### PR TITLE
fix: Fix bug when rendering BSModal in parent component OnDoRender 

### DIFF
--- a/src/BlazorStrap/Shared/Components/Modal/BSModalBase.cs
+++ b/src/BlazorStrap/Shared/Components/Modal/BSModalBase.cs
@@ -133,10 +133,10 @@ namespace BlazorStrap.Shared.Components.Modal
                 // If anything fails callback will will be handled after render.
                 if (_objectRef != null)
                 {
-                    if (_callback != null)
+                    var cb = Interlocked.Exchange(ref _callback, null);
+                    if (cb != null)
                     {
-                        await _callback();
-                        _callback = null;
+                        await cb();
                     }
                 }
                 else
@@ -418,10 +418,10 @@ namespace BlazorStrap.Shared.Components.Modal
                 BlazorStrapService.OnEventForward += InteropEventCallback;
                 BlazorStrapService.ModalChange += OnModalChange;
             }
-            if (_callback != null)
+            var cb = Interlocked.Exchange(ref _callback, null);
+            if (cb != null)
             {
-                await _callback.Invoke();
-                _callback = null;
+                await cb();
             }
         }
         public async ValueTask DisposeAsync()


### PR DESCRIPTION
Use Interlocked.Exchange to set BSModalBase internal _callback to null if it is about to be invoked. This ensures that it is not invoked multiple times when rendering under complex scenarios.

When you ShowAsync the modal within the parent component OnDoRender function (on first render), the Modal is left in a broken state. It is shown, then immediately disappears but the grey backdrom remains.

This bug is present on `master`. Showcased in the following repo (note, please update *.csproj references to point to your local repo of BlazorStrap / BlazorStrap.V5, and ensure the repo is clean / up to date.  https://github.com/m-chandler/blazor-modal-onfirstrender-bug

Component code is also here if you prefer not having to check out a repo etc.

```
<BSModal DataId="modal1" @ref="Modal">
    <Header>Modal Title</Header>
    <Content>Woohoo, you're reading this text in a modal!</Content>
    <Footer Context="modal">
        <BSButton MarginStart="Margins.Auto" Color="BSColor.Secondary">Close</BSButton>
        <BSButton Color="BSColor.Primary" OnClick="modal.HideAsync">Save changes</BSButton>
    </Footer>
</BSModal>

@code
{
    public BSModal Modal { get; set; }

    protected override async Task OnAfterRenderAsync(bool firstRender)
    {
        if (firstRender)
        {
            await Modal.ShowAsync();
        }
        await base.OnAfterRenderAsync(firstRender);
    }
}
```

Could also be accomplished by the below code. It's my understanding that Blazor / WASM are heading towards multi threading support, so the use of Interlocked.Exchange felt like a better option?

**Alternative without Interlocked.Exchange**
```
var cb = _callback;
_callback = null;
if (cb != null)
{
    await cb();
}
```

Continuation of: https://github.com/chanan/BlazorStrap/issues/542
