### PR TITLE
Added NoDataColspan in BSDataTableBase

### DIFF
--- a/src/BlazorStrap.V5/Components/Datatable/BSDataTable.razor
+++ b/src/BlazorStrap.V5/Components/Datatable/BSDataTable.razor
@@ -18,7 +18,7 @@
         @if (!Items?.Any() ?? true)
         {
             <tr>
-                <td>
+                <td Colspan="@NoDataColspan">
                     @NoData
                 </td>
             </tr>

--- a/src/BlazorStrap/Shared/Components/Datatable/BSDataTableBase.cs
+++ b/src/BlazorStrap/Shared/Components/Datatable/BSDataTableBase.cs
@@ -59,6 +59,11 @@ namespace BlazorStrap.Shared.Components.Datatable
         [Parameter, AllowNull] public RenderFragment? NoData { get; set; }
 
         /// <summary>
+        /// Sets the colspan value when <see cref="NoData"/> is shown
+        /// </summary>
+        [Parameter] public int NoDataColspan { get; set; } = 1;
+
+        /// <summary>
         /// Enable page navigation at the top of the table.
         /// </summary>
         [Parameter] public bool PaginationTop { get; set; }


### PR DESCRIPTION
Added Colspan to a TD element, to allow spanning over the entire row, when no data is available ...

```
<BSDataTable Items="Lst" Context="L" PaginationBottom="false" IsStriped="true" IsResponsive="true" NoDataColspan="3">
	<Header>
		<BSTD>Firstname</BSTD>
		<BSTD>Lastname</BSTD>
		<BSTD>a number</BSTD>
	</Header>
	<NoData>
		No Data
	</NoData>
	<Body>
		<BSDataTableRow>
			<BSTD>@L.FirstName</BSTD>
			<BSTD>@L.Lastname</BSTD>
			<BSTD>@L.Number.ToString()</BSTD>
		</BSDataTableRow>
	</Body>
</BSDataTable>

```