### PR TITLE
Typo docs index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@
                                 <h3 class="card-header">BlazorStrap V1</h3>
                                 <img src="logo.svg" class="card-img-top bg-purple-gradient" alt="..." />
                                 <div class="card-body">
-                                    Obsolate - Bootstrap 4
+                                    Obsolete - Bootstrap 4
                                 </div>
                             </a>
                         </div>


### PR DESCRIPTION
This fixes a typo on the docs main page as it was the first thing I saw.