### PR TITLE
Fixed: When DefaultShown = true, BSCollapse can't be hidden

### DIFF
--- a/src/BlazorStrap/Shared/Components/Common/BSCollapseBase.cs
+++ b/src/BlazorStrap/Shared/Components/Common/BSCollapseBase.cs
@@ -38,7 +38,15 @@ namespace BlazorStrap.Shared.Components.Common
         public bool DefaultShown
         {
             get => _defaultShown;
-            set { _defaultShown = value; if (!_hasRendered) Shown = value; }
+            set
+            {
+                _defaultShown = value;
+                if (!_hasRendered)
+                {
+                    Shown = value;
+                    _shown = value;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When `DefaultShown` is `true` BSCollapse can't be hidden