### PR TITLE
fix issue that column medium is not working for BSLabel

### DIFF
--- a/src/BlazorStrap.V4/Components/Forms/BSLabel.razor.cs
+++ b/src/BlazorStrap.V4/Components/Forms/BSLabel.razor.cs
@@ -16,7 +16,7 @@ namespace BlazorStrap.V4
                 .AddClass("col", Column == null && ColumnSmall == null && ColumnMedium == null && ColumnLarge == null && ColumnXL == null && IsColumn)
                 .AddClass($"col-{Column}", Column.VaildGridSize() && IsColumn)
                 .AddClass($"col-sm-{ColumnSmall}", ColumnSmall.VaildGridSize() && IsColumn)
-                .AddClass($"col-md-{ColumnMedium}", ColumnSmall.VaildGridSize() && IsColumn)
+                .AddClass($"col-md-{ColumnMedium}", ColumnMedium.VaildGridSize() && IsColumn)
                 .AddClass($"col-lg-{ColumnLarge}", ColumnLarge.VaildGridSize() && IsColumn)
                 .AddClass($"col-xl-{ColumnXL}", ColumnXL.VaildGridSize() && IsColumn)
                 .AddClass($"order-{Order}", Order.VaildGridSize())

--- a/src/BlazorStrap.V5/Components/Forms/BSLabel.razor.cs
+++ b/src/BlazorStrap.V5/Components/Forms/BSLabel.razor.cs
@@ -20,7 +20,7 @@ namespace BlazorStrap.V5
                 .AddClass("col", Column == null && ColumnSmall == null && ColumnMedium == null && ColumnLarge == null && ColumnXL == null && ColumnXXL == null && IsColumn)
                 .AddClass($"col-{Column}", Column.VaildGridSize() && IsColumn)
                 .AddClass($"col-sm-{ColumnSmall}", ColumnSmall.VaildGridSize() && IsColumn)
-                .AddClass($"col-md-{ColumnMedium}", ColumnSmall.VaildGridSize() && IsColumn)
+                .AddClass($"col-md-{ColumnMedium}", ColumnMedium.VaildGridSize() && IsColumn)
                 .AddClass($"col-lg-{ColumnLarge}", ColumnLarge.VaildGridSize() && IsColumn)
                 .AddClass($"col-xl-{ColumnXL}", ColumnXL.VaildGridSize() && IsColumn)
                 .AddClass($"col-xxl-{ColumnXXL}", ColumnXXL.VaildGridSize() && IsColumn)


### PR DESCRIPTION
`ColumMedium` property is not working for `BSLabel`, it only works if `ColumnSmall` is defined, too.