### PR TITLE
Avoid exception by using TrySetResult instead of empty catch with SetResult

### DIFF
--- a/src/BlazorStrap/Shared/Components/BSCoreBase.cs
+++ b/src/BlazorStrap/Shared/Components/BSCoreBase.cs
@@ -85,12 +85,7 @@ namespace BlazorStrap.Shared.Components
             }
             else if(!firstRender && _secondRender)
             {
-                try
-                {
-                    TaskCompletionSource.SetResult(true);
-                }
-                catch { }
-                //Stops hotreload from crying
+                TaskCompletionSource.TrySetResult(true);
             }
             if (_locationChanged && _secondRender)
             {


### PR DESCRIPTION
Sometimes an `InvalidOperationException` is thrown when the `TaskCompletionSource` is set multiple times. You can avoid this exception at all if you use `TrySetResult` instead of `SetResult`.

https://github.com/chanan/BlazorStrap/blob/680021f793a9ea83e2c89c68db069321522a4f67/src/BlazorStrap/Shared/Components/BSCoreBase.cs#L88-L93