### PR TITLE
fix issue that Class is not applied to BSAlertLink

### DIFF
--- a/src/BlazorStrap.V4/Components/Common/BSAlertLink.razor
+++ b/src/BlazorStrap.V4/Components/Common/BSAlertLink.razor
@@ -1,6 +1,6 @@
 ﻿@inherits BlazorStrap.Shared.Components.Common.BSAlertLinkBase
 @namespace BlazorStrap.V4
 
-<a href="@Url" class="alert-link">
+<a href="@Url" class="@ClassBuilder">
     @ChildContent
 </a>

--- a/src/BlazorStrap.V4/Components/Common/BSAlertLink.razor.cs
+++ b/src/BlazorStrap.V4/Components/Common/BSAlertLink.razor.cs
@@ -1,3 +1,5 @@
+using BlazorComponentUtilities;
+using BlazorStrap.Extensions;
 using BlazorStrap.Shared.Components.Common;
 
 namespace BlazorStrap.V4
@@ -6,6 +8,8 @@ namespace BlazorStrap.V4
     {
         protected override string? LayoutClass => LayoutClassBuilder.Build(this);
 
-        protected override string? ClassBuilder => null;
+        protected override string? ClassBuilder => new CssBuilder("alert-link")
+            .AddClass(Class, !string.IsNullOrEmpty(Class))
+            .Build().ToNullString();
     }
 }

--- a/src/BlazorStrap.V5/Components/Common/BSAlertLink.razor
+++ b/src/BlazorStrap.V5/Components/Common/BSAlertLink.razor
@@ -1,6 +1,6 @@
 ﻿@inherits BlazorStrap.Shared.Components.Common.BSAlertLinkBase
 @namespace BlazorStrap.V5
 
-<a href="@Url" class="alert-link">
+<a href="@Url" class="@ClassBuilder">
     @ChildContent
 </a>

--- a/src/BlazorStrap.V5/Components/Common/BSAlertLink.razor.cs
+++ b/src/BlazorStrap.V5/Components/Common/BSAlertLink.razor.cs
@@ -1,3 +1,5 @@
+using BlazorComponentUtilities;
+using BlazorStrap.Extensions;
 using BlazorStrap.Shared.Components.Common;
 
 namespace BlazorStrap.V5
@@ -6,6 +8,8 @@ namespace BlazorStrap.V5
     {
         protected override string? LayoutClass => LayoutClassBuilder.Build(this);
 
-        protected override string? ClassBuilder => null;
+        protected override string? ClassBuilder => new CssBuilder("alert-link")
+            .AddClass(Class, !string.IsNullOrEmpty(Class))
+            .Build().ToNullString();
     }
 }


### PR DESCRIPTION
I wanted to make an alert link a stretched link but the value of the supplied Class was not applied. I fixed this for v4 and v5.